### PR TITLE
Fix Ln 108

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -105,7 +105,7 @@ slots:
       Use of the 'affects' predicate implies that the affected entity already exists, unlike predicates such as 'affects risk for' and 'prevents, where the outcome is something that may or may not come to be.
     in_subset: translator_minimal
     mappings:
-      - SEMMEDDB: AFFECTS
+      - SEMMEDDB:AFFECTS
   
   - name: regulates
     is_a: affects


### PR DESCRIPTION
Having `SEMMEDDB: AFFECTS` with a space makes a YAML parser think that "SEMMEDDB" is a key for a mappings object, rather than a string in a mappings list.

If we want to have whitespace in the CURIE then the string must be quoted. I assume that this whitespace was an accident, though.