### PR TITLE
UMLSSG:GENE → gene?

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1320,6 +1320,7 @@ classes:
       - "SO:0000704"
       - "SIO:010035"
       - "WD:Q7187"
+      - "UMLSSG:GENE"
     id_prefixes:
       - NCBIGene
       - ENSEMBL


### PR DESCRIPTION
Note: `UMLSSG:GENE` is also mapped onto `genomic entity`. Should it map onto both?


```
  - name: genomic entity
    is_a: molecular entity
    aliases: ['sequence feature']
    description: >-
      an entity that can either be directly located on a genome (gene, transcript, exon, regulatory region) or is encoded in a genome (protein)
    slots:
      - has biological sequence
    mappings:
      - "SO:0000110"
      - "UMLSSG:GENE"
```