### PR TITLE
fixed erroneous BFO:0000066 mappings

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -514,8 +514,7 @@ slots:
       - translator_minimal
     inverse: location of
     mappings:
-      - BFO:0000066
-      - WD:276
+      - RO:0001025
 
   location of:
     is_a: related to
@@ -527,6 +526,7 @@ slots:
     mappings:  
       - RO:0001015
       - SEMMEDDB:LOCATION_OF
+      - WD:276
 
   model of:
     is_a: related to


### PR DESCRIPTION
removed mapping of blm:located in to BFO:0000066  - and replaced with mapping to RO:0001025  (located in)
also moved mapping to WD:276 (location) from blm:located in to blm:location of