### PR TITLE
Fixing type in RO mapping of the 'prevents' slot

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -844,7 +844,7 @@ slots:
     in_subset:
       - translator_minimal
     mappings:
-      - RO:0002559
+      - RO:0002599
       - SEMMEDDB:PREVENTS
 
   correlated with:


### PR DESCRIPTION
Was mapped to RO:0002559 ! causally influenced by, but changed to map to RO:0002599 ! capable of inhibiting or preventing pathological process.