### PR TITLE
Fix evidence properties (properly use evidence_type)

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -30,8 +30,6 @@ types:
 ## Still neeed definition
   phenotype:
 
-  evidence instance:
-
   chemical formula value:
 
   identifier type:
@@ -1302,7 +1300,7 @@ slots:
 
   has evidence:
     is_a: association slot
-    range: evidence instance
+    range: evidence type
     description: >-
       connects an association to an instance of supporting evidence
     mappings:


### PR DESCRIPTION
remove useless evidence instance and use evidence type for has evidence to fix https://github.com/biolink/biolink-model/issues/153