### PR TITLE
Use the official uniprot PURLs for uniprot entries

### DIFF
--- a/context.jsonld
+++ b/context.jsonld
@@ -50,7 +50,7 @@
       "UMLSSG": "https://uts-ws.nlm.nih.gov/rest/semantic-network/semantic-network/current/GROUP/",
       "UMLSST": "https://uts-ws.nlm.nih.gov/rest/semantic-network/semantic-network/current/STY/",
       "UPHENO": "http://purl.obolibrary.org/obo/UPHENO_",
-      "UniProtKB": "http://identifiers.org/uniprot/",
+      "UniProtKB": "http://purl.uniprot.org/uniprot/",
       "VMC": "http://example.org/UNKNOWN/VMC/",
       "WB": "http://identifiers.org/wb/",
       "WD": "http://example.org/UNKNOWN/WD/",


### PR DESCRIPTION
This allows combining bio-link data painlessly with the data as it is provided by the UniProt consortium.

This purl pattern is documented do our site and is used on our SPARQL endpoint and in our schema.org markup. 