### PR TITLE
changed name of 'change is catalyzed by' slot

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1572,12 +1572,12 @@ slots:
     multivalued: true
     range: publication
 
-  change is catalyzed by:
+  catalyst qualifier:
     is_a: association slot
     multivalued: true
     range: macromolecular machine
     description: >-
-      hyperedge connecting an association between two causally connected entities (for example, two chemical entities, or a chemical entity in
+      a qualifier that connects an association between two causally connected entities (for example, two chemical entities, or a chemical entity in
       that changes location) and the gene product, gene, or complex that enables or catalyzes the change.
       
   has biological sequence:
@@ -3006,7 +3006,7 @@ classes:
       - object
       - relation
     slots:
-      - change is catalyzed by
+      - catalyst qualifier
     description: >-
       A causal relationship between two chemical entities, where the subject represents the upstream entity and the object represents the downstream.
       For any such association there is an implicit reaction:
@@ -3016,7 +3016,7 @@ classes:
         R enabled-by P AND
         R type Reaction
         THEN
-        C1 derives-into C2 <<change is catalyzed by P>>
+        C1 derives-into C2 <<catalyst qualifier P>>
     slot_usage:
       subject:
         range: chemical substance
@@ -3028,7 +3028,7 @@ classes:
           the downstream chemical entity
       relation:
         subproperty_of: derives into
-      change is catalyzed by:
+      catalyst qualifier:
         description: >-
           this connects the derivation edge to the molecular entity that catalyzes the reaction that causes the
           subject chemical to transform into the object chemical


### PR DESCRIPTION
As per discussion in #270, changed to 'catalyst qualifier'. Also updated all usages the old name.