### PR TITLE
Added or updated id_prefixes for many types

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -2102,6 +2102,15 @@ classes:
       # Neoplastic Process
       - UMLSSC:T191
       - UMLSST:neop
+    id_prefixes:
+      - MONDO
+      - DOID
+      - OMIM
+      - ORPHANET
+      - EFO
+      - UMLS
+      - MESH
+      - MEDDRA
 
   phenotypic feature:
     aliases: ['sign', 'symptom', 'phenotype', 'trait', 'endophenotype']
@@ -2111,6 +2120,12 @@ classes:
     mappings:
       - SIO:010056
       - WD:Q169872
+    id_prefixes:
+      - HP
+      - EFO
+      - NCIT
+      - UMLS
+      - MEDDRA
 
   exposure event:
     aliases: ['environment', 'exposure', 'experimental condition']
@@ -2310,6 +2325,15 @@ classes:
     id_prefixes:
       - CHEBI
       - CHEMBL.COMPOUND
+      - DRUGBANK
+      - PUBCHEM
+      - MESH
+      - HMDB
+      - INCHI
+      - INCHIKEY
+      - UNII
+      - KEGG
+      - GTOPDB
 
   carbohydrate:
     is_a: chemical substance
@@ -2371,6 +2395,9 @@ classes:
       # Body Substance
       - UMLSSC:T031
       - UMLSST:bdsu
+    id_prefixes:
+      - UBERON
+      - UMLS
 
   life stage:
     is_a: organismal entity
@@ -2508,12 +2535,14 @@ classes:
       - NCBIGene
       - ENSEMBL
       - HGNC
+      #- UNIPROTKB  I think this belongs, but others may strongly disagree CB
       - MGI
       - ZFIN
       - dictyBase
       - WB
       - SGD
       - PomBase
+      - IUPHAR
 
   gene product:
     is_a: gene or gene product
@@ -2523,6 +2552,10 @@ classes:
       - protein
       - RNA product
     class_uri: WD:Q424689
+    id_prefixes:
+      - UNIPROTKB
+      - GTOPDB
+      - PR
 
   protein:
     is_a: gene product
@@ -2675,9 +2708,14 @@ classes:
       - SIO:010277
       - VMC:Allele
     id_prefixes:
+      - CAID #ClinGen Allele Registry
       - ClinVar
       - WD
       - CIViC
+      - HGVS
+      - DBSNP
+      - MYVARIANT_HG19
+      - MYVARIANT_HG38
     alt_descriptions:
       AGR: "An enitity that describes a single affected, endogenous allele.  These can be of any type that matches that definition"
       VMC: "A contiguous change at a Location"
@@ -4010,6 +4048,10 @@ classes:
     id_prefixes:
       - GO
       - Reactome
+      - KEGG
+      - SMPDB
+      - PHARMGKB
+      - WIKIPATHWAYS
 
   physiological process:
     aliases: ['physiology']
@@ -4040,6 +4082,9 @@ classes:
       # Clinical Attribute
       - UMLSSC:T201
       - UMLSST:clna
+    id_prefixes:
+      - GO
+      - Reactome
 
   cellular component:
     is_a: anatomical entity
@@ -4068,6 +4113,7 @@ classes:
     id_prefixes:
       - CL
       - PO
+      - UMLS
 
   cell line:
     is_a: organismal entity


### PR DESCRIPTION
My understanding is that the id_prefixes of types are supposed to be an ordered list of the allowed prefixes for nodes in a Translator graph.  So for chemical_substance, we'd like to have CHEBI first, but if the thing doesn't have a CHEBI, we look for a CHEMBL.COMPOUND, but after that, we need further fallbacks.   

I've added all the prefixes that we've built up in robokop over time across multiple types.

The other thing that we use this list for is determining what the allowed values of prefixes for equivalent identifiers is.  So let's say that every gene has an NCBIGene id, which is the preferred prefix for genes.   Then you might think that the list beyond that is unimportant.  However, we still want this longer list because when we create our equivalent_id property for a node, we might end up with all kinds of junk in there, and this list of prefixes tells us which ones we should keep.