### PR TITLE
Moreprefixes

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -2407,7 +2407,11 @@ classes:
       - UMLSST:bdsu
     id_prefixes:
       - UBERON
+      - GO
+      - CL
       - UMLS
+      - MESH
+      - NCIT
 
   life stage:
     is_a: organismal entity

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -2111,6 +2111,11 @@ classes:
       - UMLS
       - MESH
       - MEDDRA
+      - NCIT
+      - SNOMEDCT
+      - medgen
+      - HP
+      - MP
 
   phenotypic feature:
     aliases: ['sign', 'symptom', 'phenotype', 'trait', 'endophenotype']
@@ -2126,6 +2131,8 @@ classes:
       - NCIT
       - UMLS
       - MEDDRA
+      - SNOMEDCT
+      - MP
 
   exposure event:
     aliases: ['environment', 'exposure', 'experimental condition']

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -4113,6 +4113,12 @@ classes:
       - UMLSST:celc
     id_prefixes:
       - GO
+      - MESH
+      - UMLS
+      - NCIT
+      - SNOMEDCT
+      - CL
+      - UBERON
 
   cell:
     is_a: anatomical entity
@@ -4128,6 +4134,10 @@ classes:
       - CL
       - PO
       - UMLS
+      - NCIT
+      - MESH
+      - UBERON
+      - SNOMEDCT
 
   cell line:
     is_a: organismal entity

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -3948,6 +3948,9 @@ classes:
       - GO
       - Reactome
       - RHEA
+      - MetaCyc
+      - EC
+      - KEGG.REACTION
 
   activity and behavior:
     is_a: occurrent
@@ -4051,6 +4054,9 @@ classes:
     id_prefixes:
       - GO
       - Reactome
+      - MetaCyc
+      - KEGG.PATHWAY
+      - KEGG.REACTION
 
   pathway:
     is_a: biological process

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -2342,7 +2342,7 @@ classes:
       - INCHI
       - INCHIKEY
       - UNII
-      - KEGG
+      - KEGG.COMPOUND
       - GTOPDB
 
   carbohydrate:

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -2114,6 +2114,9 @@ classes:
       - NCIT
       - SNOMEDCT
       - medgen
+      - ICD-10
+      - ICD-9
+      - ICD-0
       - HP
       - MP
 


### PR DESCRIPTION
We're working on a node normalization prototype service.   It decides what the (1) best and (2) valid identifiers for an entity are by looking at the prefixes from the `id_prefix` tags on semantic types.  This pull request adds a few of these id_prefixes.

One thing that's unclear to me is what the source of prefixes should be.  I've tried to make these mostly come from identifiers.org, but I'm not sure if that's the correct source or not.