### PR TITLE
Add enables relation

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1077,13 +1077,24 @@ slots:
       - translator_minimal
     slot_uri: RO:0002215
 
+  enables:
+    is_a: has participant
+    description: >-
+      holds between a physical entity and a process, where the physical entity executes the process
+    range: biological process or activity
+    in_subset:
+      - translator_minimal
+    inverse: enabled by
+    slot_uri: RO:0002327
+
   enabled by:
     is_a: has participant
     description: >-
       holds between a process and a physical entity, where the physical entity executes the process
-    range: biological process or activity
+    domain: biological process or activity
     in_subset:
       - translator_minimal
+    inverse: enables
     slot_uri: RO:0002333
 
   derives into:


### PR DESCRIPTION
Adding `enables` relation, which is inverse of `enabled by`.

Also changed the constraint for `enabled by`. Previously the range for `enabled by` was `biological process or activity` when it actually should be the domain.

@cmungall Thoughts?