### PR TITLE
Fixing class/slot URIs

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1835,7 +1835,8 @@ classes:
   onset:
     description: >-
       The age group in which manifestations appear
-    class_uri: HP:0003674
+    mappings:
+      - HP:0003674
     is_a: attribute
 
   relationship quantifier:
@@ -1873,8 +1874,8 @@ classes:
       - name
       - category
     subclass_of: BFO:0000001
-    class_uri: WD:Q35120
     mappings:
+      - WD:Q35120
       # UMLS Semantic Group "Objects"
       - UMLSSG:OBJC
       # Entity
@@ -1892,7 +1893,8 @@ classes:
 
   data file:
     is_a: named thing
-    class_uri: EFO:0004095
+    mappings:
+      - EFO:0004095
 
   source file:
     is_a: data file
@@ -1906,7 +1908,8 @@ classes:
 
   data set:
     is_a: named thing
-    class_uri: IAO:0000100
+    mappings:
+      - IAO:0000100
 
   data set version:
     is_a: data set
@@ -1933,8 +1936,8 @@ classes:
   biological entity:
     is_a: named thing
     abstract: true
-    class_uri: WD:Q28845870
     mappings:
+      - WD:Q28845870
       # UMLS Semantic Type "Experimental Model of Disease"
       - UMLSSC:T050
       - UMLSST:emod
@@ -1967,22 +1970,24 @@ classes:
     is_a: ontology class
     values_from:
       - NCBITaxon
-    class_uri: WD:Q16521
+    mappings:
+      - WD:Q16521
 
   organismal entity:
     description: >-
       A named entity that is either a part of an organism, a whole organism, population or clade of organisms, excluding molecular entities
     abstract: true
     is_a: biological entity
-    class_uri: WD:Q7239
+    mappings:
+      - WD:Q7239
 
   individual organism:
     mixins:
       - thing with taxon
     is_a: organismal entity
     subclass_of: "NCBITaxon:1"
-    class_uri: SIO:010000
     mappings:
+      - SIO:010000
       - WD:Q795052
       # UMLS Semantic Group "Living Beings"
       # Several of the associated semantic types here are probably not
@@ -2066,8 +2071,8 @@ classes:
       - thing with taxon
     is_a: organismal entity
     subclass_of: PCO:0000001
-    class_uri: SIO:001061
     mappings:
+      - SIO:001061
       # UMLS Semantic Type "Population Group"
       - UMLSSC:T098
       - UMLSST:popg
@@ -2115,8 +2120,8 @@ classes:
   disease:
     aliases: ['condition', 'disorder', 'medical condition']
     is_a: disease or phenotypic feature
-    class_uri: MONDO:0000001
     mappings:
+      - MONDO:0000001
       - WD:Q12136
       - SIO:010299
       # UMLS Semantic Group "Disorders"
@@ -2165,8 +2170,8 @@ classes:
     aliases: ['sign', 'symptom', 'phenotype', 'trait', 'endophenotype']
     is_a: disease or phenotypic feature
     subclass_of: UPHENO:0001001
-    class_uri: UPHENO:0001001
     mappings:
+      - UPHENO:0001001
       - SIO:010056
       - WD:Q169872
     id_prefixes:
@@ -2182,7 +2187,8 @@ classes:
     description: >-
       A feature of the environment of an organism that influences one or more phenotypic features
       of that organism, potentially mediated by genes
-    class_uri: SIO:000955
+    mappings:
+      - SIO:000955
 
   information content entity:
     aliases: ['information', 'information artefact', 'information entity']
@@ -2190,8 +2196,8 @@ classes:
     is_a: named thing
     description: >-
       a piece of information that typically describes some piece of biology or is used as support.
-    class_uri: IAO:0000030
     mappings:
+      - IAO:0000030
       # UMLS Semantic Group "Concepts & Ideas"
       - UMLSSG:CONC
       # Conceptual Entity
@@ -2234,7 +2240,8 @@ classes:
       Level of confidence in a statement
     values_from:
       - cio
-    class_uri: CIO:0000028
+    mappings:
+      - CIO:0000028
 
   evidence type:
     is_a: information content entity
@@ -2243,7 +2250,8 @@ classes:
       Class of evidence that supports an association
     values_from:
       - eco
-    class_uri: ECO:0000000
+    mappings:
+      - ECO:0000000
 
   publication:
     is_a: information content entity
@@ -2252,8 +2260,8 @@ classes:
       Any published piece of information. Can refer to a whole publication,
       or to a part of it (e.g. a figure, figure legend, or section highlighted by NLP).
       The scope is intended to be general and include information published on the web as well as journals.
-    class_uri: IAO:0000311
     mappings:
+      - IAO:0000311
       # UMLS Semantic Type "Intellectual Product"
       - UMLSSC:T170
       - UMLSST:inpr
@@ -2294,8 +2302,8 @@ classes:
     description: "A gene, gene product, small molecule or macromolecule (including protein complex)"
     #notes:
     #  - "Check SIO mapping - also mapped to chemical substance.": Resolved by changing SIO:010004 to SIO:010341
-    class_uri: SIO:010341
     mappings:
+      - SIO:010341
       - WD:Q43460564
       # UMLS Semantic Group "Genes & Molecular Sequences"
       - UMLSSG:GENE
@@ -2309,8 +2317,8 @@ classes:
       May be a chemical entity or a formulation with a chemical entity as active ingredient, or a complex
       material with multiple chemical entities as part
     subclass_of: "CHEBI:24431"
-    class_uri: SIO:010004
     mappings:
+      - SIO:010004
       - WD:Q79529
       # UMLS Semantic Type "Substance"
       - UMLSSC:T167
@@ -2397,8 +2405,8 @@ classes:
       A substance intended for use in the diagnosis, cure, mitigation, treatment, or prevention of disease
     comments:
       - The CHEBI ID represents a role rather than a substance
-    class_uri: WD:Q12140
     mappings:
+      - WD:Q12140
       - CHEBI:23888
       # UMLS Semantic Type "Clinical Drug"
       - UMLSSC:T200
@@ -2410,7 +2418,8 @@ classes:
       Any intermediate or product resulting from metabolism. Includes primary and secondary metabolites.
     comments:
       - The CHEBI ID represents a role rather than a substance
-    class_uri: CHEBI:25212
+    mappings:
+      - CHEBI:25212
 #
 #    attribute:
 #    subclass_of: PATO:0000001
@@ -2427,8 +2436,8 @@ classes:
     subclass_of: UBERON:0001062
     description: >-
       A subcellular location, cell type or gross anatomical part
-    class_uri: SIO:010046
     mappings:
+      - SIO:010046
       - WD:Q4936952
       # UMLS Semantic Group "Anatomy"
       - UMLSSG:ANAT
@@ -2505,8 +2514,8 @@ classes:
       an entity that can either be directly located on a genome (gene, transcript, exon, regulatory region) or is encoded in a genome (protein)
     slots:
       - has biological sequence
-    class_uri: SO:0000110
     mappings:
+      - SO:0000110
       # Gene or Genome
       - UMLSSC:T028
       - UMLSST:gngm
@@ -2517,8 +2526,8 @@ classes:
     is_a: genomic entity
     description: >-
       A genome is the sum of genetic material within a cell or virion.
-    class_uri: SO:0001026
     mappings:
+      - SO:0001026
       - SIO:000984
       - WD:Q7020
 
@@ -2526,23 +2535,23 @@ classes:
     is_a: genomic entity
     description: >-
       An RNA synthesized on a DNA or RNA template by an RNA polymerase
-    class_uri: SO:0000673
     mappings:
+      - SO:0000673
       - SIO:010450
 
   exon:
     is_a: genomic entity
     description: >-
       A region of the transcript sequence within a gene which is not removed from the primary RNA transcript by RNA splicing
-    class_uri: SO:0000147
     mappings:
+      - SO:0000147
       - SIO:010445
       - WD:Q373027
 
   coding sequence:
     is_a: genomic entity
-    class_uri: SO:0000316
     mappings:
+      - SO:0000316
       - SIO:001390
 
   macromolecular machine:
@@ -2576,8 +2585,8 @@ classes:
   gene:
     is_a: gene or gene product
     aliases: ['locus']
-    class_uri: SO:0000704
     mappings:
+      - SO:0000704
       - SIO:010035
       - WD:Q7187
     id_prefixes:
@@ -2600,7 +2609,8 @@ classes:
     union_of:
       - protein
       - RNA product
-    class_uri: WD:Q424689
+    mappings:
+      - WD:Q424689
     id_prefixes:
       - UNIPROTKB
       - GTOPDB
@@ -2611,8 +2621,8 @@ classes:
     aliases: ['polypeptide']
     description: >-
       A gene product that is composed of a chain of amino acid sequences and is produced by ribosome-mediated translation of mRNA
-    class_uri: PR:000000001
     mappings:
+      - PR:000000001
       - SIO:010043
       - WD:Q8054
       # UMLS Semantic Type: "Amino Acid Sequence"
@@ -2649,8 +2659,8 @@ classes:
 
   RNA product:
     is_a: gene product
-    class_uri: CHEBI:33697
     mappings:
+      - CHEBI:33697
       - SIO:010450
       - WD:Q11053
     id_prefixes:
@@ -2672,13 +2682,14 @@ classes:
       - NCBIGene
       - ENSEMBL
     subclass_of: SO:0000655
-    class_uri: SIO:001235
+    mappings:
+      - SIO:001235
 
   microRNA:
     is_a: noncoding RNA product
     subclass_of: SO:0000276
-    class_uri: SIO:001397
     mappings:
+      - SIO:001397
       - WD:Q310899
     id_prefixes:
       - MIR
@@ -2686,8 +2697,8 @@ classes:
   macromolecular complex:
     is_a: macromolecular machine
     subclass_of: "GO:0032991"
-    class_uri: SIO:010046
     mappings:
+      - SIO:010046
       - WD:Q22325163
     id_prefixes:
       - IntAct
@@ -2703,8 +2714,8 @@ classes:
 
   gene family:
     is_a: molecular entity
-    class_uri: SIO:001380
     mappings:
+      - SIO:001380
       - "NCIT:C20130"
       - WD:Q417841
     mixins:
@@ -2716,7 +2727,8 @@ classes:
 
   zygosity:
     is_a: attribute
-    class_uri: GENO:0000133
+    mappings:
+      - GENO:0000133
 
   genotype:
     is_a: genomic entity
@@ -2726,8 +2738,8 @@ classes:
       - Consider renaming as genotypic entity
     slots:
       - has zygosity
-    class_uri: GENO:0000536
     mappings:
+      - GENO:0000536
       - SIO:001079
 
   haplotype:
@@ -2736,8 +2748,8 @@ classes:
       A set of zero or more Alleles on a single instance of a Sequence[VMC]
 #    slots:
 #      - completeness
-    class_uri: GENO:0000871
     mappings:
+      - GENO:0000871
       - VMC:Haplotype
 
   sequence variant:
@@ -2751,8 +2763,8 @@ classes:
       - >-
           This class is for modeling the specific state at a locus. A single dbSNP rs ID could correspond to more
           than one sequence variants (e.g CIViC:1252 and CIViC:1253, two distinct BRCA2 alleles for rs28897743)
-    class_uri: GENO:0000002
     mappings:
+      - GENO:0000002
       - WD:Q15304597
       - SIO:010277
       - VMC:Allele
@@ -2796,7 +2808,8 @@ classes:
 #        range: chemical substance
 #        required: true
 #        multivalued: true
-    class_uri: ECTO:9000000
+    mappings:
+      - ECTO:9000000
 
   drug exposure:
     aliases: ['drug intake', 'drug dose']
@@ -2810,8 +2823,8 @@ classes:
         range: chemical substance
         required: true
         multivalued: true
-    class_uri: ECTO:0000509
     mappings:
+      - ECTO:0000509
       - SIO:001005
 
   treatment:
@@ -2824,8 +2837,8 @@ classes:
         multivalued: true
         range: drug exposure
         required: true
-    class_uri: OGMS:0000090
     mappings:
+      - OGMS:0000090
       - SIO:001398
 
   geographic location:
@@ -2867,8 +2880,8 @@ classes:
       - qualifiers
       - publications
       - provided by
-    class_uri: OBAN:association
     mappings:
+      - OBAN:association
       - "rdf:Statement"
       - "owl:Axiom"
 
@@ -3133,7 +3146,8 @@ classes:
         
   chemical to disease or phenotypic feature association:
     is_a: association
-    class_uri: SIO:000993
+    mappings:
+      - SIO:000993
     defining_slots:
       - subject
       - object
@@ -3150,7 +3164,8 @@ classes:
 
   chemical to pathway association:
     is_a: association
-    class_uri: SIO:001250
+    mappings:
+      - SIO:001250
     defining_slots:
       - subject
       - object
@@ -3165,7 +3180,8 @@ classes:
 
   chemical to gene association:
     is_a: association
-    class_uri: SIO:001257
+    mappings:
+      - SIO:001257
     defining_slots:
       - subject
       - object
@@ -3331,7 +3347,8 @@ classes:
     description: >-
       An association between either a disease or a phenotypic feature and an anatomical entity,
       where the disease/feature manifests in that site.
-    class_uri: NCIT:R100
+    mappings:
+      - NCIT:R100
     slot_usage:
       object:
         range: anatomical entity
@@ -3438,7 +3455,8 @@ classes:
 
   gene to phenotypic feature association:
     is_a: association
-    class_uri: http://bio2rdf.org/wormbase_vocabulary:Gene-Phenotype-Association
+    mappings:
+      - http://bio2rdf.org/wormbase_vocabulary:Gene-Phenotype-Association
     defining_slots:
       - subject
       - object
@@ -3457,7 +3475,8 @@ classes:
     is_a: association
     comments:
       - NCIT:R176 refers to the inverse relationship
-    class_uri: SIO:000983
+    mappings:
+      - SIO:000983
     defining_slots:
       - subject
       - object
@@ -3754,7 +3773,8 @@ classes:
   gene to go term association:
     aliases: ['functional association']
     is_a: functional association
-    class_uri: http://bio2rdf.org/wormbase_vocabulary:Gene-GO-Association
+    mappings:
+      - http://bio2rdf.org/wormbase_vocabulary:Gene-GO-Association
     defining_slots:
       - subject
       - object
@@ -3801,7 +3821,8 @@ classes:
       - end interbase coordinate
       - genome build
       - phase
-    class_uri: faldo:location
+    mappings:
+      - faldo:location
 
   sequence feature relationship:
     is_a: association
@@ -3929,7 +3950,8 @@ classes:
     description: >-
       A processual entity
     is_a: named thing
-    class_uri: BFO:0000003
+    mappings:
+      - BFO:0000003
 
   physical entity:
     description: >-
@@ -3960,7 +3982,6 @@ classes:
       - occurrent
     description: >-
       An execution of a molecular function carried out by a gene product or macromolecular complex.
-    class_uri: GO:0003674
     slot_usage:
       has input:
         range: chemical substance
@@ -3975,6 +3996,7 @@ classes:
         description: >-
           The gene product, gene, or complex that catalyzes the reaction
     mappings:
+      - GO:0003674
       # UMLS Semantic Type "Molecular Function"
       - UMLSSC:T044
       - UMLSST:moft
@@ -4078,8 +4100,8 @@ classes:
       - occurrent
     description: >-
       One or more causally connected executions of molecular functions
-    class_uri: GO:0008150
     mappings:
+      - GO:0008150
       - SIO:000006
       - WD:Q2996394
     id_prefixes:
@@ -4088,8 +4110,8 @@ classes:
 
   pathway:
     is_a: biological process
-    class_uri: GO:0007165
     mappings:
+      - GO:0007165
       - SIO:010526
       - PW:0000001
       - WD:Q4915012
@@ -4138,8 +4160,8 @@ classes:
     is_a: anatomical entity
     description: >-
       A location in or around a cell
-    class_uri: GO:0005575
     mappings:
+      - GO:0005575
       - SIO:001400
       - WD:Q5058355
       # Cell Component
@@ -4150,8 +4172,8 @@ classes:
 
   cell:
     is_a: anatomical entity
-    class_uri: GO:0005623
     mappings:
+      - GO:0005623
       - CL:0000000
       - SIO:010001
       - WD:Q7868
@@ -4165,15 +4187,16 @@ classes:
 
   cell line:
     is_a: organismal entity
-    class_uri: CLO:0000031
+    mappings:
+      - CLO:0000031
     id_prefixes:
       - CLO
 
   gross anatomical structure:
     aliases: ['tissue', 'organ']
     is_a: anatomical entity
-    class_uri: UBERON:0010000
     mappings:
+      - UBERON:0010000
       - SIO:010046
       - WD:Q4936952
       # UMLS Semantic Type "Anatomical Structure"

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -118,9 +118,9 @@ slots:
     domain: named thing
     range: named thing
     multivalued: true
-    slot_uri: owl:ObjectProperty
     inherited: true
     mappings:
+      - owl:topObjectProperty
       - SEMMEDDB:ASSOCIATED_WITH
 
   interacts with:
@@ -131,7 +131,8 @@ slots:
     is_a: related to
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002434
+    mappings:
+      - RO:0002434
 
   physically interacts with:
     is_a: interacts with
@@ -140,8 +141,8 @@ slots:
     in_subset:
       - translator_minimal
     symmetric: true
-    slot_uri: WD:P129
     mappings:
+      - WD:P129
       - SEMMEDDB:INTERACTS_WITH
 
   molecularly interacts with:
@@ -150,7 +151,8 @@ slots:
     range: molecular entity
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002436
+    mappings:
+      - RO:0002436
 
   genetically interacts with:
     is_a: interacts with
@@ -160,7 +162,8 @@ slots:
     range: gene
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002435
+    mappings:
+      - RO:0002435
 
   affects:
     is_a: related to
@@ -169,7 +172,8 @@ slots:
       Use of the 'affects' predicate implies that the affected entity already exists, unlike predicates such as 'affects risk for' and 'prevents, where the outcome is something that may or may not come to be.
     in_subset:
       - translator_minimal
-    slot_uri: SEMMEDDB:AFFECTS
+    mappings:
+      - SEMMEDDB:AFFECTS
 
   affects abundance of:
     description: >-
@@ -609,7 +613,8 @@ slots:
       - This is a grouping for process-process and entity-entity relations
     mixin: true
     abstract: true
-    slot_uri: WD:P128
+    mappings:
+      - WD:P128
 
   positively regulates:
     comments:
@@ -629,19 +634,22 @@ slots:
     is_a: regulates
     domain: occurrent
     range: occurrent
-    slot_uri: RO:0002211
+    mappings:
+      - RO:0002211
 
   positively regulates, process to process:
     is_a: regulates, process to process
     mixins:
       - positively regulates
-    slot_uri: RO:0002213
+    mappings:
+      - RO:0002213
 
   negatively regulates, process to process:
     is_a: regulates, process to process
     mixins:
       - negatively regulates
-    slot_uri: RO:0002212
+    mappings:
+      - RO:0002212
 
   regulates, entity to entity:
     aliases: ['activity directly regulates activity of']
@@ -653,7 +661,8 @@ slots:
       ro: activity directly regulates activity of
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002448
+    mappings:
+      - RO:0002448
 
   positively regulates, entity to entity:
     aliases: ['activity directly positively regulates activity of']
@@ -665,8 +674,8 @@ slots:
       ro: activity directly positively regulates activity of
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002450
     mappings:
+      - RO:0002450
       - SEMMEDDB:STIMULATES
 
   negatively regulates, entity to entity:
@@ -679,8 +688,8 @@ slots:
       ro: activity directly negatively regulates activity of
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002449
     mappings:
+      - RO:0002449
       - SEMMEDDB:INHIBITS
 
   disrupts:
@@ -689,7 +698,8 @@ slots:
       describes a relationship where one entity degrades or interferes with the structure, function, or occurrence of another.
     in_subset:
       - translator_minimal
-    slot_uri: SEMMEDDB:DISRUPTS
+    mappings:
+      - SEMMEDDB:DISRUPTS
 
   has gene product:
     is_a: related to
@@ -699,8 +709,8 @@ slots:
     range: gene product
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002205
     mappings:
+      - RO:0002205
       - WD:P688
 
   homologous to:
@@ -712,8 +722,8 @@ slots:
       - typically used to describe homology relationships between genes or gene products
     in_subset:
       - translator_minimal
-    slot_uri: RO:HOM0000001
     mappings:
+      - RO:HOM0000001
       - SIO:010302
 
   paralogous to:
@@ -722,7 +732,8 @@ slots:
       a homology relationship that holds between entities (typically genes) that diverged after a duplication event.
     in_subset:
       - translator_minimal
-    slot_uri: RO:HOM0000011
+    mappings:
+      - RO:HOM0000011
 
   orthologous to:
     is_a: homologous to
@@ -730,8 +741,8 @@ slots:
       a homology relationship between entities (typically genes) that diverged after a speciation event.
     in_subset:
       - translator_minimal
-    slot_uri: RO:HOM0000017
     mappings:
+      - RO:HOM0000017
       - WD:P684
 
   xenologous to:
@@ -740,7 +751,8 @@ slots:
       a homology relationship characterized by an interspecies (horizontal) transfer since the common ancestor.
     in_subset:
       - translator_minimal
-    slot_uri: RO:HOM0000018
+    mappings:
+      - RO:HOM0000018
 
   coexists with:
     is_a: related to
@@ -748,7 +760,8 @@ slots:
       holds between two entities that are co-located in the same aggregate object, process, or spatio-temporal region
     in_subset:
       - translator_minimal
-    slot_uri: SEMMEDDB:COEXISTS_WITH
+    mappings:
+      - SEMMEDDB:COEXISTS_WITH
 
   in pathway with:
     description: >-
@@ -783,7 +796,8 @@ slots:
     is_a: coexists with
     in_subset:
       - translator_minimal
-    slot_uri: RO:00002325
+    mappings:
+      - RO:00002325
 
   gene associated with condition:
     is_a: related to
@@ -793,7 +807,8 @@ slots:
     range: disease or phenotypic feature
     in_subset:
       - translator_minimal
-    slot_uri: WD:P2293
+    mappings:
+      - WD:P2293
 
   affects risk for:
     is_a: related to
@@ -808,7 +823,8 @@ slots:
       holds between two entities where exposure to one entity increases the chance of developing the other
     in_subset:
       - translator_minimal
-    slot_uri: SEMMEDDB:PREDISPOSES
+    mappings:
+      - SEMMEDDB:PREDISPOSES
 
   contributes to:
     is_a: related to
@@ -816,7 +832,8 @@ slots:
       holds between two entities where the occurrence, existence, or activity of one causes or contributes to the occurrence or generation of the other
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002326
+    mappings:
+      - RO:0002326
 
   causes:
     description: >-
@@ -824,9 +841,9 @@ slots:
     is_a: contributes to
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002410
     inverse: caused by
     mappings:
+      - RO:0002410
       - SEMMEDDB:CAUSES
       - WD:P1542
 
@@ -851,8 +868,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: treated by
-    slot_uri: RO:0002606
     mappings:
+      - RO:0002606
       - RO:0003307
       - SEMMEDDB:TREATS
       - WD:P2175
@@ -865,8 +882,8 @@ slots:
       the onset a disease or phenotypic feature.
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002599
     mappings:
+      - RO:0002599
       - SEMMEDDB:PREVENTS
 
   correlated with:
@@ -877,7 +894,8 @@ slots:
     range: molecular entity
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002610
+    mappings:
+      - RO:0002610
 
   has biomarker:
     is_a: correlated with
@@ -898,7 +916,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: has biomarker
-    slot_uri: RO:0002607
+    mappings:
+      - RO:0002607
 
   treated by:
     is_a: related to
@@ -908,8 +927,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: treats
-    slot_uri: RO:0002302
     mappings:
+      - RO:0002302
       - WD:P2176
 
   expressed in:
@@ -921,7 +940,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: expresses
-    slot_uri: RO:0002206
+    mappings:
+      - RO:0002206
 
   expresses:
     is_a: related to
@@ -932,7 +952,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: expressed in
-    slot_uri: RO:0002292
+    mappings:
+      - RO:0002292
 
   has phenotype:
     is_a: related to
@@ -944,7 +965,8 @@ slots:
       - check the range
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002200
+    mappings:
+      - RO:0002200
 
   occurs in:
     is_a: related to
@@ -952,8 +974,8 @@ slots:
       holds between a process and a material entity or site within which the process occurs
     in_subset:
       - translator_minimal
-    slot_uri: BFO:0000066
     mappings:
+      - BFO:0000066
       - SEMMEDDB:OCCURS_IN
       - SEMMEDDB:PROCESS_OF
 
@@ -964,7 +986,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: location of
-    slot_uri: RO:0001025
+    mappings:
+      - RO:0001025
 
   location of:
     is_a: related to
@@ -973,8 +996,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: located in
-    slot_uri: RO:0001015
     mappings:
+      - RO:0001015
       - SEMMEDDB:LOCATION_OF
       - WD:276
 
@@ -984,7 +1007,8 @@ slots:
       holds between an entity and some other entity it approximates for purposes of scientific study, in virtue of its exhibiting similar features of the studied entity.
     in_subset:
       - translator_minimal
-    slot_uri: RO:0003301
+    mappings:
+      - RO:0003301
 
   overlaps:
     is_a: related to
@@ -992,7 +1016,8 @@ slots:
       holds between entties that overlap in their extents (materials or processes)
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002131
+    mappings:
+      - RO:0002131
 
   has part:
     is_a: overlaps
@@ -1001,8 +1026,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: part of
-    slot_uri: BFO:0000051
     mappings:
+      - BFO:0000051
       - WD:P527
 
   part of:
@@ -1012,8 +1037,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: has part
-    slot_uri: BFO:0000050
     mappings:
+      - BFO:0000050
       - SEMMEDDB:PART_OF
       - WD:P361
 
@@ -1025,8 +1050,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: participates in
-    slot_uri: RO:0000057
     mappings:
+      - RO:0000057
      - WD:P2283
 
   has input:
@@ -1036,8 +1061,8 @@ slots:
     domain: occurrent
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002233
     mappings:
+      - RO:0002233
       - SEMMEDDB:USES
 
   has output:
@@ -1047,7 +1072,8 @@ slots:
     domain: occurrent
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002234
+    mappings:
+      - RO:0002234
 
   participates in:
     is_a: related to
@@ -1057,7 +1083,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: has participant
-    slot_uri: RO:0000056
+    mappings:
+      - RO:0000056
 
   actively involved in:
     is_a: participates in
@@ -1066,7 +1093,8 @@ slots:
     range: occurrent
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002331
+    mappings:
+      - RO:0002331
 
   capable of:
     is_a: actively involved in
@@ -1075,7 +1103,8 @@ slots:
     range: occurrent
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002215
+    mappings:
+      - RO:0002215
 
   enabled by:
     is_a: has participant
@@ -1084,7 +1113,8 @@ slots:
     range: biological process or activity
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002333
+    mappings:
+      - RO:0002333
 
   derives into:
     is_a: related to
@@ -1093,8 +1123,8 @@ slots:
     in_subset:
       - translator_minimal
     inverse: derives from
-    slot_uri: RO:0001001
     mappings:
+      - RO:0001001
       - SEMMEDDB:CONVERTS_TO
 
   derives from:
@@ -1105,7 +1135,8 @@ slots:
       - translator_minimal
       - samples
     inverse: derives into
-    slot_uri: RO:0001000
+    mappings:
+      - RO:0001000
 
   manifestation of:
     is_a: related to
@@ -1114,8 +1145,8 @@ slots:
     range: disease
     in_subset:
       - translator_minimal
-    slot_uri: SEMMEDDB:MANIFESTATION_OF
     mappings:
+      - SEMMEDDB:MANIFESTATION_OF
       - WD:P1557
 
   produces:
@@ -1124,8 +1155,8 @@ slots:
       holds between a material entity and a product that is generated through the intentional actions or functioning of the material entity
     in_subset:
       - translator_minimal
-    slot_uri: RO:0003000
     mappings:
+      - RO:0003000
       - WD:P1056
       - SEMMEDDB:PRODUCES
 
@@ -1137,8 +1168,8 @@ slots:
     range: occurrent
     in_subset:
       - translator_minimal
-    slot_uri: BFO:0000063
     mappings:
+      - BFO:0000063
       - SEMMEDDB:PRECEDES
       - WD:P156
 
@@ -1148,8 +1179,8 @@ slots:
       holds between two entities that are considered equivalent to each other
     in_subset:
       - translator_minimal
-    slot_uri: owl:equivalentClass
     mappings:
+      - owl:equivalentClass
       - owl:sameAs
       - skos:exactMatch
       - WD:P2888
@@ -1163,8 +1194,8 @@ slots:
     multivalued: True
     in_subset:
       - translator_minimal
-    slot_uri: rdfs:subClassOf
     mappings:
+      - rdfs:subClassOf
       - SEMMEDDB:IS_A
       - WD:P279
 
@@ -1178,50 +1209,59 @@ slots:
   title:
     is_a: node property
     domain: data set version
-    slot_uri: dct:title
+    mappings:
+      - dct:title
 
   source data file:
     is_a: node property
     domain: data set version
     range: data file
-    slot_uri: dcterms:source
+    mappings:
+      - dcterms:source
 
   source web page:
     is_a: node property
     domain: data set summary
-    slot_uri: dcterms:source
+    mappings:
+      - dcterms:source
 
   retrievedOn:
     is_a: node property
     domain: source file
     range: date
-    slot_uri: pav:retrievedOn
+    mappings:
+      - pav:retrievedOn
 
   versionOf:
     is_a: node property
     domain: data set version
     range: data set
-    slot_uri: dct:isVersionOf
+    mappings:
+      - dct:isVersionOf
 
   source version:
     is_a: node property
     domain: source file
-    slot_uri: pav:version
+    mappings:
+      - pav:version
 
   downloadURL:
     is_a: node property
     domain: distribution level
-    slot_uri: dct:downloadURL
+    mappings:
+      - dct:downloadURL
 
   distribution:
     is_a: node property
     domain: data set version
     range: distribution level
-    slot_uri: void:Dataset
+    mappings:
+      - void:Dataset
 
   type:
     is_a: node property
-    slot_uri: rdf:type
+    mappings:
+      - rdf:type
 
   id:
     is_a: node property
@@ -1279,7 +1319,7 @@ slots:
     in_subset:
       - translator_minimal
     required: true
-    slot_uri: rdfs:subClassOf
+    slot_uri: rdf:type
 
   full name:
     is_a: node property
@@ -1397,28 +1437,32 @@ slots:
     range: evidence type
     description: >-
       connects an association to an instance of supporting evidence
-    slot_uri: RO:0002558
+    mappings:
+      - RO:0002558
 
   provided by:
     is_a: association slot
     range: provider
     description: >-
       connects an association to the agent (person, organization or group) that provided it
-    slot_uri: pav:providedBy
+    mappings:
+      - pav:providedBy
 
   association type:
     is_a: association slot
     range: ontology class
     description: >-
       connects an association to the type of association (e.g. gene to phenotype)
-    slot_uri: rdf:type
+    mappings:
+      - rdf:type
 
   creation date:
     is_a: node property
     range: date
     description: >-
       date on which thing was created. This can be applied to nodes or edges
-    slot_uri: dcterms:created
+    mappings:
+      - dcterms:created
 
   has receptor:
     is_a: node property
@@ -1426,7 +1470,8 @@ slots:
     range: organismal entity
     description: >-
       the organism or organism part being exposed
-    slot_uri: ExO:0000001
+    mappings:
+      - ExO:0000001
 
   has stressor:
     is_a: node property
@@ -1434,14 +1479,16 @@ slots:
     aliases: ['has stimulus']
     description: >-
       the process or entity that the receptor is being exposed to
-    slot_uri: ExO:0000000
+    mappings:
+      - ExO:0000000
 
   has route:
     is_a: node property
     domain: exposure event
     description: >-
       the process that results in the stressor coming into direct contact with the receptor
-    slot_uri: ExO:0000055
+    mappings:
+      - ExO:0000055
 
   update date:
     is_a: node property
@@ -1457,8 +1504,8 @@ slots:
       connects a thing to a class representing a taxon
     in_subset:
       - translator_minimal
-    slot_uri: RO:0002162
     mappings:
+      - RO:0002162
       - WD:P703
 
   latitude:
@@ -1466,21 +1513,24 @@ slots:
     range: float
     description: >-
       latitude
-    slot_uri: wgs:lat
+    mappings:
+      - wgs:lat
 
   longitude:
     is_a: node property
     range: float
     description: >-
       longitude
-    slot_uri: wgs:long
+    mappings:
+      - wgs:long
 
   has chemical formula:
     is_a: node property
     range: chemical formula value
     description: >-
       description of chemical compound based on element symbols
-    slot_uri: WD:P274
+    mappings:
+      - WD:P274
 
   aggregate statistic:
     is_a: node property


### PR DESCRIPTION
@RichardBruskiewich @mbrush @deepakunni3 @hsolbrig 

This fix clarifies #246. In most places the default URI to use is the blmod one, except in certain cases (reification, rdfs:label)