### PR TITLE
Fix all occurrences of UNIPROTKB prefix

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -2584,7 +2584,7 @@ classes:
       - NCBIGene
       - ENSEMBL
       - HGNC
-      #- UNIPROTKB  I think this belongs, but others may strongly disagree CB
+      #- UniProtKB  I think this belongs, but others may strongly disagree CB
       - MGI
       - ZFIN
       - dictyBase
@@ -2603,7 +2603,7 @@ classes:
     mappings:
       - WD:Q424689
     id_prefixes:
-      - UNIPROTKB
+      - UniProtKB
       - GTOPDB
       - PR
 


### PR DESCRIPTION
Fix all occurrences of `UNIPROTKB` and replace them with the canonical `UniProtKB` prefix.

Resolves #358 