### PR TITLE
Moved NCIT:R100 from an association to a slot

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1346,6 +1346,7 @@ slots:
       - UBERON_CORE:in_central_side_of
       - UBERON_CORE:in_innermost_side_of
       - UBERON_CORE:in_outermost_side_of
+      - NCIT:R100
 
   location of:
     is_a: related to
@@ -3960,8 +3961,6 @@ classes:
     description: >-
       An association between either a disease or a phenotypic feature and an anatomical entity,
       where the disease/feature manifests in that site.
-    mappings:
-      - NCIT:R100
     slot_usage:
       object:
         range: anatomical entity


### PR DESCRIPTION
NCIT:R100 is "Disease_Has_Associated_Anatomic_Site".  But it's currently a mapping to an association instead of a slot.

This PR removes the mapping to the association, and instead adds it to a slot (located in).

In general, per discussion with @deepakunni3  and @mbrush on Friday, predicate mappings should be to slots (descendents of related to) and not to associations.