### PR TITLE
Adding Biolink Model version tag

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -3,6 +3,9 @@ name: Biolink-Model
 description: Entity and association taxonomy and datamodel for life-sciences data
 license: https://creativecommons.org/publicdomain/zero/1.0/
 
+# Version should be kept in sync with primary Git repository release tag
+version: 1.3.8
+
 # CURIE namespaces (prefixes/base URI's) mappings of prefixes used in the body of the Biolink Model specification are resolved using a specific precedence order,
 # for use in the generation of the Biolink Model context.jsonld mappings to namespaces. Any prefixes encountered in the Biolink Model but not resolved by the following 
 # precedence sources, are anonymously declared by biolinkml as http://example.org/UNKNOWN/ rooted base URI's which should ideally be repaired in one of the precedence lists.


### PR DESCRIPTION
As discussed. @deepakunni3 indicates that the Biolink Model is at release 1.3.8. @hsolbrig suggested that the version tag could be (biolinkml) safely added (as good versioning practice)

_**TODO:**_ would be nice to have some kind of "best practices" mechanism to automate synchronization between major Github version tags (to releases) and the embedded version tag of the code.

This pull request relates to https://github.com/biolink/biolink-model/issues/326. See also the Biolink ML issue https://github.com/biolink/biolinkml/issues/217 for a broader discussion.
