### PR TITLE
Fix camelCase slots

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -2582,7 +2582,7 @@ classes:
     is_a: data file
     slots:
       - source version
-      - retrievedOn
+      - retrieved on
 
 #  data set descriptor:
 #    abstract: true
@@ -2599,7 +2599,7 @@ classes:
       - title
 #      - description
       - source data file
-      - versionOf
+      - version of
       - type
       - distribution
     mappings:
@@ -2609,7 +2609,7 @@ classes:
     is_a: data set version
     mixin: true
     slots:
-      - downloadURL
+      - download url
     mappings:
       - dcat:Distribution
 

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1833,14 +1833,14 @@ slots:
     mappings:
       - dcterms:source
 
-  retrievedOn:
+  retrieved on:
     is_a: node property
     domain: source file
     range: date
     mappings:
       - pav:retrievedOn
 
-  versionOf:
+  version of:
     is_a: node property
     domain: data set version
     range: data set
@@ -1878,7 +1878,7 @@ slots:
     mappings:
       - pav:createdWith
 
-  downloadURL:
+  download url:
     is_a: node property
     domain: distribution level
     mappings:


### PR DESCRIPTION
CURIEs for slots are typically snake_case, which I believe requires that the yaml contain no uppercase letters, even for acronyms. "iri" is already lowercase, so hopefully doing the same with "download url" is okay.