### PR TITLE
Deprecate 'edge_label' in favor of 'predicate'

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -101,8 +101,16 @@ types:
     description: >-
       A string that provides a human-readable name for a thing
 
+  predicate type:
+    typeof: uriorcurie
+    description: >-
+      A CURIE from the biolink related_to hierarchy.
+      For example, biolink:related_to, biolink:causes, biolink:treats.
+
   edge label type:
     typeof: uriorcurie
+    deprecated: Deprecated in favor of 'predicate type'
+    deprecated_element_has_exact_replacement: predicate type
     description: >-
       A CURIE from the biolink related_to hierarchy.
       For example, biolink:related_to, biolink:causes, biolink:treats.
@@ -2131,7 +2139,7 @@ slots:
       - owl:annotatedTarget
       - OBAN:association_has_object
 
-  edge label:
+  predicate:
     is_a: association slot
     description: >-
       A high-level grouping for the relationship type. AKA minimal predicate.
@@ -2141,7 +2149,7 @@ slots:
       Has a value from the Biolink related_to hierarchy. In RDF, this corresponds to rdf:predicate and
       in Neo4j this corresponds to the relationship type.
       The convention is for an edge label in snake_case form. For example, biolink:related_to, biolink:causes, biolink:treats
-    range: edge label type
+    range: predicate type
     required: true
     local_names:
       ga4gh: annotation predicate
@@ -2150,6 +2158,19 @@ slots:
     mappings:
       - owl:annotatedProperty
       - OBAN:association_has_predicate
+
+  edge label:
+    deprecated: >-
+      This slot is deprecated in favor of 'predicate' slot.
+    deprecated_element_has_exact_replacement: predicate
+    is_a: association slot
+    domain: association
+    range: edge label type
+    required: true
+    local_names:
+      ga4gh: annotation predicate
+      translator: predicate
+    slot_uri: rdf:predicate
 
   relation:
     is_a: association slot


### PR DESCRIPTION
Based on discussions on the Data Modeling Committee, Architecture Committee, and the Reasoner API WG, `biolink:edge_label` is being deprecated in favor of `biolink:predicate`.