### PR TITLE
Deprecation persistence?

### DIFF
--- a/guidelines/maintaining-the-model.md
+++ b/guidelines/maintaining-the-model.md
@@ -45,7 +45,7 @@ In the above example we use the `deprecated` and `deprecated_element_has_exact_r
 - Using the `deprecated` slot one can provide a human readable description of why the slot was deprecated
 - Using the `deprecated_element_has_exact_replacement` slot one can define what is the ideal replacement for this slot (if any)
 
-It's recommended that deprecated classes and slots remain in the model until the next minor release.
+It's recommended that deprecated classes and slots remain in the model until the next major release.
 
 
 ## Artifacts

--- a/guidelines/maintaining-the-model.md
+++ b/guidelines/maintaining-the-model.md
@@ -65,4 +65,4 @@ This step is automated as part of [GitHub Actions](https://github.com/biolink/bi
 
 The [Biolink Model Documentation](https://biolink.github.io/biolink-model/) site is driven from the `gh-pages` branch.
 
-That means no pull request to the Biolink Model repo should include generated Markdown.
+That means no pull request to the Biolink Model repo should include generated Markdown. It is advised to ensure that [GitHub Actions](https://github.com/biolink/biolink-model/actions) remain disabled in the fork from which pull requests are made back to the main Biolink repository.


### PR DESCRIPTION
Just wondering whether or not deprecated  model items should  remain in the  mode until the next 'major' release since their deletion may compromise backwards compatibility of the model (violation of that is usually only ok at  the  'major' release level)