### PR TITLE
Biolink Issue #546 - adding EDAM

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -31,6 +31,7 @@ prefixes:
   doi: 'https://doi.org/'
   DrugCentral: 'http://translator.ncats.nih.gov/DrugCentral_'
   ECTO: 'http://purl.obolibrary.org/obo/ECTO_'
+  EDAM: 'http://edamontology.org/'
   ExO: 'http://purl.obolibrary.org/obo/ExO_'
   fabio: 'http://purl.org/spar/fabio/'
   foaf: 'http://xmlns.com/foaf/0.1/'


### PR DESCRIPTION
We use the *identifiers.org* strategy of just using the `EDAM:` curie prefix and to represent the term subsets of EDAM by the prefixes in their object identifiers.