### PR TITLE
BiolinkML  1.6.1 upgrade

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-biolinkml = ">=1.5.10"
+biolinkml = ">=1.6.1"
 
 [dev-packages]
 


### PR DESCRIPTION
Latest version of  BiolinkML  christened by  Harold,  includes bug fix patches for  `mixin`  parsing.