### PR TITLE
Add prefix for panther pathways

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -5450,6 +5450,7 @@ classes:
       - PHARMGKB.PATHWAYS
       - WIKIPATHWAYS
       - FlyBase ## FlyBase:FBgg
+      - PANTHER.PATHWAY
 
   physiological process:
     aliases: ['physiology']


### PR DESCRIPTION
Required in order to normalize panther pathways.