### PR TITLE
remove slot_uri from subclass of

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1185,7 +1185,6 @@ slots:
     in_subset:
       - translator_minimal
     inverse: superclass of
-    slot_uri: rdfs:subClassOf
     close_mappings:
       # RTX mapped terms, would this rather mean that a 'class A' class of an 'instance B'
       # and a an 'instance B' has class 'class A' (inverse term)


### PR DESCRIPTION
subclass of is a "related to" not an association slot. 
So I think it should not have a defined slot_uri (just as e.g. superclass of does not).

The reason this is a problem is that for all other predicates, I can use the toolkit get_element().slot_uri to get a predicate like
"biolink:superclass_of".  But if I do that with subclass I get "rdfs:SubclassOf" which annoys things that are expecting to find biolink:whatever.