### PR TITLE
replace commas in model names. 

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -2390,54 +2390,54 @@ slots:
     mixin: true
     inverse: negatively regulates
 
-  regulates, process to process:
+  process regulates process:
     is_a: affects
     mixins:
       - regulates
     domain: occurrent
     range: occurrent
-    inverse: regulated by, process to process
+    inverse: process regulated by process
     exact_mappings:
       - RO:0002211
 
-  regulated by, process to process:
+  process regulated by process:
     is_a: affected by
     domain: occurrent
     range: occurrent
-    inverse: regulates, process to process
+    inverse: process regulates process
 
-  positively regulates, process to process:
-    is_a: regulates, process to process
+  process positively regulates process:
+    is_a: process regulates process
     mixins:
       - positively regulates
-    inverse: positively regulated by, process to process
+    inverse: process positively regulated by process
     exact_mappings:
       - RO:0002213
 
-  positively regulated by, process to process:
-    is_a: regulated by, process to process
-    inverse: positively regulates, process to process
+  process positively regulated by process:
+    is_a: process regulated by process
+    inverse: process positively regulates process
 
-  negatively regulates, process to process:
-    is_a: regulates, process to process
+  process negatively regulates process:
+    is_a: process regulates process
     mixins:
       - negatively regulates
-    inverse: negatively regulated by, process to process
+    inverse: process negatively regulated by process
     exact_mappings:
       - RO:0002212
 
-  negatively regulated by, process to process:
-    is_a: regulated by, process to process
-    inverse: negatively regulates, process to process
+  process negatively regulated by process:
+    is_a: process regulated by process
+    inverse: process negatively regulates process
 
-  regulates, entity to entity:
+  entity regulates entity:
     aliases: ['activity directly regulates activity of']
     is_a: affects
     mixins:
       - regulates
     domain: molecular entity
     range: molecular entity
-    inverse: regulated by, entity to entity
+    inverse: entity regulated by entity
     local_names:
       translator: regulates
       ro: activity directly regulates activity of
@@ -2452,18 +2452,18 @@ slots:
       # may also be another class of chemical_substance?
       - WIKIDATA_PROPERTY:P128
 
-  regulated by, entity to entity:
+  entity regulated by entity:
     is_a: affected by
     domain: molecular entity
     range: molecular entity
-    inverse: regulates, entity to entity
+    inverse: entity regulates entity
 
-  positively regulates, entity to entity:
+  entity positively regulates entity:
     aliases: ['activity directly positively regulates activity of']
-    is_a: regulates, entity to entity
+    is_a: entity regulates entity
     mixins:
       - positively regulates
-    inverse: positively regulated by, entity to entity
+    inverse: entity positively regulated by entity
     local_names:
       translator: positively regulates
       ro: activity directly positively regulates activity of
@@ -2484,16 +2484,16 @@ slots:
       # Positive regulation is defined more narrowly here, as "Disease upregulates Gene"
       - hetio:UPREGULATES_DuG
 
-  positively regulated by, entity to entity:
-    is_a: regulated by, entity to entity
-    inverse: positively regulates, entity to entity
+  entity positively regulated by entity:
+    is_a: entity regulated by entity
+    inverse: entity positively regulates entity
 
-  negatively regulates, entity to entity:
+  entity negatively regulates entity:
     aliases: ['activity directly negatively regulates activity of']
-    is_a: regulates, entity to entity
+    is_a: entity regulates entity
     mixins:
       - negatively regulates
-    inverse: negatively regulated by, entity to entity
+    inverse: entity negatively regulated by entity
     local_names:
       translator: negatively regulates
       ro: activity directly negatively regulates activity of
@@ -2510,9 +2510,9 @@ slots:
       # Down regulation is defined more narrowly here, as "Disease downregulates Gene"
       - hetio:DOWNREGULATES_DdG
 
-  negatively regulated by, entity to entity:
-    is_a: regulated by, entity to entity
-    inverse: negatively regulates, entity to entity
+  entity negatively regulated by entity:
+    is_a: entity regulated by entity
+    inverse: entity negatively regulates entity
 
   disrupts:
     is_a: affects
@@ -3930,7 +3930,7 @@ slots:
     description: >-
       one or more nutrients which are growth factors for a living organism
     domain: food
-    range: nutrient
+    range: food component
     in_subset:
       - translator_minimal
     inverse: nutrient of

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -3891,8 +3891,8 @@ slots:
     description: >-
       holds between a one or more chemical substances present in food,
       irrespective of nutritional value (i.e. could also be a contaminant or additive)
-    domain: food component
-    range: food
+    domain: chemical substance
+    range: chemical substance
     in_subset:
       - translator_minimal
     inverse: has food component
@@ -3904,8 +3904,8 @@ slots:
     description: >-
       holds between food and one or more chemical substances composing it,
       irrespective of nutritional value (i.e. could also be a contaminant or additive)
-    domain: food
-    range: food component
+    domain: chemical substance
+    range: chemical substance
     in_subset:
       - translator_minimal
     inverse: food component of
@@ -3917,8 +3917,8 @@ slots:
     description: >-
       holds between a one or more chemical substances present in food,
       irrespective of nutritional value (i.e. could also be a contaminant or additive)
-    domain: food component
-    range: food
+    domain: chemical substance
+    range: chemical substance
     in_subset:
       - translator_minimal
     inverse: has nutrient
@@ -3929,8 +3929,8 @@ slots:
     is_a: has food component
     description: >-
       one or more nutrients which are growth factors for a living organism
-    domain: food
-    range: food component
+    domain: chemical substance
+    range: chemical substance
     in_subset:
       - translator_minimal
     inverse: nutrient of
@@ -5951,25 +5951,28 @@ classes:
   ## Food
 
   food component:
+    deprecated: >-
+      Food component is replaced by a slot/role of chemical substance and will be removed
+      from the Biolink model.
     is_a: chemical substance
     related_mappings:
       # substance role
       - CHEBI:78295
 
   environmental food contaminant:
-    is_a: food component
+    is_a: chemical substance
     related_mappings:
       # substance role
       - CHEBI:78299
 
   food additive:
-    is_a: food component
+    is_a: chemical substance
     related_mappings:
       # substance role
       - CHEBI:64047
 
   nutrient:
-    is_a: food component
+    is_a: chemical substance
     related_mappings:
       # substance role
       - CHEBI:33284

--- a/biolink/model.py
+++ b/biolink/model.py
@@ -1,5 +1,5 @@
 # Auto generated from biolink-model.yaml by pythongen.py version: 0.9.0
-# Generation date: 2021-02-19 20:26
+# Generation date: 2021-03-04 13:16
 # Schema: Biolink-Model
 #
 # id: https://w3id.org/biolink/biolink-model
@@ -498,15 +498,15 @@ class FoodComponentId(ChemicalSubstanceId):
     pass
 
 
-class EnvironmentalFoodContaminantId(FoodComponentId):
+class EnvironmentalFoodContaminantId(ChemicalSubstanceId):
     pass
 
 
-class FoodAdditiveId(FoodComponentId):
+class FoodAdditiveId(ChemicalSubstanceId):
     pass
 
 
-class NutrientId(FoodComponentId):
+class NutrientId(ChemicalSubstanceId):
     pass
 
 
@@ -2668,7 +2668,7 @@ class FoodComponent(ChemicalSubstance):
 
 
 @dataclass
-class EnvironmentalFoodContaminant(FoodComponent):
+class EnvironmentalFoodContaminant(ChemicalSubstance):
     _inherited_slots: ClassVar[List[str]] = ["in_taxon"]
 
     class_class_uri: ClassVar[URIRef] = BIOLINK.EnvironmentalFoodContaminant
@@ -2689,7 +2689,7 @@ class EnvironmentalFoodContaminant(FoodComponent):
 
 
 @dataclass
-class FoodAdditive(FoodComponent):
+class FoodAdditive(ChemicalSubstance):
     _inherited_slots: ClassVar[List[str]] = ["in_taxon"]
 
     class_class_uri: ClassVar[URIRef] = BIOLINK.FoodAdditive
@@ -2710,7 +2710,7 @@ class FoodAdditive(FoodComponent):
 
 
 @dataclass
-class Nutrient(FoodComponent):
+class Nutrient(ChemicalSubstance):
     _inherited_slots: ClassVar[List[str]] = ["in_taxon"]
 
     class_class_uri: ClassVar[URIRef] = BIOLINK.Nutrient
@@ -8263,41 +8263,41 @@ slots.negatively_regulates = Slot(uri=BIOLINK.negatively_regulates, name="negati
 slots.negatively_regulated_by = Slot(uri=BIOLINK.negatively_regulated_by, name="negatively regulated by", curie=BIOLINK.curie('negatively_regulated_by'),
                    model_uri=BIOLINK.negatively_regulated_by, domain=None, range=Optional[Union[dict, "PhysicalEssenceOrOccurrent"]])
 
-slots.regulates_process_to_process = Slot(uri=BIOLINK.regulates_process_to_process, name="regulates, process to process", curie=BIOLINK.curie('regulates_process_to_process'),
-                   model_uri=BIOLINK.regulates_process_to_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
+slots.process_regulates_process = Slot(uri=BIOLINK.process_regulates_process, name="process regulates process", curie=BIOLINK.curie('process_regulates_process'),
+                   model_uri=BIOLINK.process_regulates_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
 
-slots.regulated_by_process_to_process = Slot(uri=BIOLINK.regulated_by_process_to_process, name="regulated by, process to process", curie=BIOLINK.curie('regulated_by_process_to_process'),
-                   model_uri=BIOLINK.regulated_by_process_to_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
+slots.process_regulated_by_process = Slot(uri=BIOLINK.process_regulated_by_process, name="process regulated by process", curie=BIOLINK.curie('process_regulated_by_process'),
+                   model_uri=BIOLINK.process_regulated_by_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
 
-slots.positively_regulates_process_to_process = Slot(uri=BIOLINK.positively_regulates_process_to_process, name="positively regulates, process to process", curie=BIOLINK.curie('positively_regulates_process_to_process'),
-                   model_uri=BIOLINK.positively_regulates_process_to_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
+slots.process_positively_regulates_process = Slot(uri=BIOLINK.process_positively_regulates_process, name="process positively regulates process", curie=BIOLINK.curie('process_positively_regulates_process'),
+                   model_uri=BIOLINK.process_positively_regulates_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
 
-slots.positively_regulated_by_process_to_process = Slot(uri=BIOLINK.positively_regulated_by_process_to_process, name="positively regulated by, process to process", curie=BIOLINK.curie('positively_regulated_by_process_to_process'),
-                   model_uri=BIOLINK.positively_regulated_by_process_to_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
+slots.process_positively_regulated_by_process = Slot(uri=BIOLINK.process_positively_regulated_by_process, name="process positively regulated by process", curie=BIOLINK.curie('process_positively_regulated_by_process'),
+                   model_uri=BIOLINK.process_positively_regulated_by_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
 
-slots.negatively_regulates_process_to_process = Slot(uri=BIOLINK.negatively_regulates_process_to_process, name="negatively regulates, process to process", curie=BIOLINK.curie('negatively_regulates_process_to_process'),
-                   model_uri=BIOLINK.negatively_regulates_process_to_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
+slots.process_negatively_regulates_process = Slot(uri=BIOLINK.process_negatively_regulates_process, name="process negatively regulates process", curie=BIOLINK.curie('process_negatively_regulates_process'),
+                   model_uri=BIOLINK.process_negatively_regulates_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
 
-slots.negatively_regulated_by_process_to_process = Slot(uri=BIOLINK.negatively_regulated_by_process_to_process, name="negatively regulated by, process to process", curie=BIOLINK.curie('negatively_regulated_by_process_to_process'),
-                   model_uri=BIOLINK.negatively_regulated_by_process_to_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
+slots.process_negatively_regulated_by_process = Slot(uri=BIOLINK.process_negatively_regulated_by_process, name="process negatively regulated by process", curie=BIOLINK.curie('process_negatively_regulated_by_process'),
+                   model_uri=BIOLINK.process_negatively_regulated_by_process, domain=None, range=Optional[Union[Union[dict, "Occurrent"], List[Union[dict, "Occurrent"]]]])
 
-slots.regulates_entity_to_entity = Slot(uri=BIOLINK.regulates_entity_to_entity, name="regulates, entity to entity", curie=BIOLINK.curie('regulates_entity_to_entity'),
-                   model_uri=BIOLINK.regulates_entity_to_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
+slots.entity_regulates_entity = Slot(uri=BIOLINK.entity_regulates_entity, name="entity regulates entity", curie=BIOLINK.curie('entity_regulates_entity'),
+                   model_uri=BIOLINK.entity_regulates_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
 
-slots.regulated_by_entity_to_entity = Slot(uri=BIOLINK.regulated_by_entity_to_entity, name="regulated by, entity to entity", curie=BIOLINK.curie('regulated_by_entity_to_entity'),
-                   model_uri=BIOLINK.regulated_by_entity_to_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
+slots.entity_regulated_by_entity = Slot(uri=BIOLINK.entity_regulated_by_entity, name="entity regulated by entity", curie=BIOLINK.curie('entity_regulated_by_entity'),
+                   model_uri=BIOLINK.entity_regulated_by_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
 
-slots.positively_regulates_entity_to_entity = Slot(uri=BIOLINK.positively_regulates_entity_to_entity, name="positively regulates, entity to entity", curie=BIOLINK.curie('positively_regulates_entity_to_entity'),
-                   model_uri=BIOLINK.positively_regulates_entity_to_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
+slots.entity_positively_regulates_entity = Slot(uri=BIOLINK.entity_positively_regulates_entity, name="entity positively regulates entity", curie=BIOLINK.curie('entity_positively_regulates_entity'),
+                   model_uri=BIOLINK.entity_positively_regulates_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
 
-slots.positively_regulated_by_entity_to_entity = Slot(uri=BIOLINK.positively_regulated_by_entity_to_entity, name="positively regulated by, entity to entity", curie=BIOLINK.curie('positively_regulated_by_entity_to_entity'),
-                   model_uri=BIOLINK.positively_regulated_by_entity_to_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
+slots.entity_positively_regulated_by_entity = Slot(uri=BIOLINK.entity_positively_regulated_by_entity, name="entity positively regulated by entity", curie=BIOLINK.curie('entity_positively_regulated_by_entity'),
+                   model_uri=BIOLINK.entity_positively_regulated_by_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
 
-slots.negatively_regulates_entity_to_entity = Slot(uri=BIOLINK.negatively_regulates_entity_to_entity, name="negatively regulates, entity to entity", curie=BIOLINK.curie('negatively_regulates_entity_to_entity'),
-                   model_uri=BIOLINK.negatively_regulates_entity_to_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
+slots.entity_negatively_regulates_entity = Slot(uri=BIOLINK.entity_negatively_regulates_entity, name="entity negatively regulates entity", curie=BIOLINK.curie('entity_negatively_regulates_entity'),
+                   model_uri=BIOLINK.entity_negatively_regulates_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
 
-slots.negatively_regulated_by_entity_to_entity = Slot(uri=BIOLINK.negatively_regulated_by_entity_to_entity, name="negatively regulated by, entity to entity", curie=BIOLINK.curie('negatively_regulated_by_entity_to_entity'),
-                   model_uri=BIOLINK.negatively_regulated_by_entity_to_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
+slots.entity_negatively_regulated_by_entity = Slot(uri=BIOLINK.entity_negatively_regulated_by_entity, name="entity negatively regulated by entity", curie=BIOLINK.curie('entity_negatively_regulated_by_entity'),
+                   model_uri=BIOLINK.entity_negatively_regulated_by_entity, domain=MolecularEntity, range=Optional[Union[Union[str, MolecularEntityId], List[Union[str, MolecularEntityId]]]])
 
 slots.disrupts = Slot(uri=BIOLINK.disrupts, name="disrupts", curie=BIOLINK.curie('disrupts'),
                    model_uri=BIOLINK.disrupts, domain=NamedThing, range=Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]])
@@ -8477,16 +8477,16 @@ slots.has_metabolite = Slot(uri=BIOLINK.has_metabolite, name="has metabolite", c
                    model_uri=BIOLINK.has_metabolite, domain=ChemicalSubstance, range=Optional[Union[Union[str, ChemicalSubstanceId], List[Union[str, ChemicalSubstanceId]]]])
 
 slots.food_component_of = Slot(uri=BIOLINK.food_component_of, name="food component of", curie=BIOLINK.curie('food_component_of'),
-                   model_uri=BIOLINK.food_component_of, domain=FoodComponent, range=Optional[Union[Union[str, FoodId], List[Union[str, FoodId]]]])
+                   model_uri=BIOLINK.food_component_of, domain=ChemicalSubstance, range=Optional[Union[Union[str, ChemicalSubstanceId], List[Union[str, ChemicalSubstanceId]]]])
 
 slots.has_food_component = Slot(uri=BIOLINK.has_food_component, name="has food component", curie=BIOLINK.curie('has_food_component'),
-                   model_uri=BIOLINK.has_food_component, domain=Food, range=Optional[Union[Union[str, FoodComponentId], List[Union[str, FoodComponentId]]]])
+                   model_uri=BIOLINK.has_food_component, domain=ChemicalSubstance, range=Optional[Union[Union[str, ChemicalSubstanceId], List[Union[str, ChemicalSubstanceId]]]])
 
 slots.nutrient_of = Slot(uri=BIOLINK.nutrient_of, name="nutrient of", curie=BIOLINK.curie('nutrient_of'),
-                   model_uri=BIOLINK.nutrient_of, domain=FoodComponent, range=Optional[Union[Union[str, FoodId], List[Union[str, FoodId]]]])
+                   model_uri=BIOLINK.nutrient_of, domain=ChemicalSubstance, range=Optional[Union[Union[str, ChemicalSubstanceId], List[Union[str, ChemicalSubstanceId]]]])
 
 slots.has_nutrient = Slot(uri=BIOLINK.has_nutrient, name="has nutrient", curie=BIOLINK.curie('has_nutrient'),
-                   model_uri=BIOLINK.has_nutrient, domain=Food, range=Optional[Union[Union[str, NutrientId], List[Union[str, NutrientId]]]])
+                   model_uri=BIOLINK.has_nutrient, domain=ChemicalSubstance, range=Optional[Union[Union[str, ChemicalSubstanceId], List[Union[str, ChemicalSubstanceId]]]])
 
 slots.is_active_ingredient_of = Slot(uri=BIOLINK.is_active_ingredient_of, name="is active ingredient of", curie=BIOLINK.curie('is_active_ingredient_of'),
                    model_uri=BIOLINK.is_active_ingredient_of, domain=ChemicalSubstance, range=Optional[Union[Union[str, DrugId], List[Union[str, DrugId]]]], mappings = [OBOREL["0002249"]])


### PR DESCRIPTION
- in the regulates hierarchy, remove commas from class names and predicates. 
- fix nutrient warning about range value of nutrient vs. food product. 
- fixes #92 
- fixes #660