### PR TITLE
Correcting the exact mapings for CTD positive and negative correlation.

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -3197,7 +3197,7 @@ slots:
       - translator_minimal
     symmetric: true
     exact_mappings:
-      - CTD:positivecorrelation
+      - CTD:positive_correlation
 
   negatively correlated with:
     is_a: correlated with
@@ -3209,7 +3209,7 @@ slots:
       - translator_minimal
     symmetric: true
     exact_mappings:
-      - CTD:negativecorrelation
+      - CTD:negative_correlation
 
   coexpressed with:
     is_a: correlated with


### PR DESCRIPTION
 CTD positive and negative correlations should be snake_case.
 
See issue #654

thanks!