### PR TITLE
fixes 665 - add associated environmental context as a slot

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -8749,6 +8749,8 @@ classes:
       Example: plague transmitted_by flea; cattle domesticated_by Homo sapiens; plague infects Homo sapiens
     defining_slots:
       - predicate
+    slots:
+      - associated environmental context
     slot_usage:
       subject:
         range: organism taxon


### PR DESCRIPTION
This change was to fix a bit of documentation that was missing because the slot was missing from the class.