### PR TITLE
fixes 727 - kept two versions of WB prefix as WormBase supports one a…

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -6544,9 +6544,9 @@ classes:
       - ZFIN
       - dictyBase
       - WB
-      - WormBase
+      - WormBase # we have two prefixes here as worbase supports WormBase:WBGene00000898
+                 # and alliancegenome.org and identifiers.org supports WB:WBGene00000898.
       - FB  # FlyBase FBgn*
-      - FB
       - RGD
       - SGD
       - POMBASE


### PR DESCRIPTION
…nd Alliance and identifiers.org support the other.