### PR TITLE
Add Xenbase as a Gene prefix

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -124,6 +124,7 @@ prefixes:
   WIKIDATA: 'https://www.wikidata.org/wiki/'            # Wikidata Entity
   WIKIDATA_PROPERTY: 'https://www.wikidata.org/wiki/Property:'  # Wikidata Property - not a conventional namespace prefix
   wgs: 'http://www.w3.org/2003/01/geo/wgs84_pos'
+  XPO: 'http://purl.obolibrary.org/obo/XPO_'  # Xenopus Phenotype Ontology
 
 default_prefix: biolink
 default_range: string

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -6366,6 +6366,7 @@ classes:
       - WBPhenotype
       - SNOMEDCT
       - MESH
+      - XPO
     in_subset:
       - model_organism_database
 

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -6553,6 +6553,7 @@ classes:
       - OMIM
       - KEGG.GENE ## org:gene
       - UMLS
+      - Xenbase
       # - IUPHAR
     in_subset:
       - model_organism_database


### PR DESCRIPTION
It looks like gene might be the only class that needs a Xenbase prefix, I'll add to genotype or sequence_variant if they turn out to be necessary