### PR TITLE
adding NCBIGene as a prefix to the list. fixes #725

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -83,6 +83,7 @@ prefixes:
   MetaCyc: 'http://translator.ncats.nih.gov/MetaCyc_'
   MI: 'http://purl.obolibrary.org/obo/MI_'
   MSigDB: 'https://www.gsea-msigdb.org/gsea/msigdb/'
+  NCBIGene: 'http://identifiers.org/ncbigene/'
   NDDF: 'http://purl.bioontology.org/ontology/NDDF/'
   NLMID: 'https://www.ncbi.nlm.nih.gov/nlmcatalog/?term='
   OBAN: 'http://purl.org/oban/'


### PR DESCRIPTION
Since the upstream source of NCBIGene is giving it the wrong capitalization, hardcode NCBIGene in the model for now. 

