### PR TITLE
Should protein have an in_taxon slot?

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7966,6 +7966,7 @@ classes:
     is_a: polypeptide
     mixins:
       - gene product mixin
+      - thing with taxon
     exact_mappings:
       - PR:000000001
       - SIO:010043


### PR DESCRIPTION
I noticed gene has an in_taxon slot but protein does not and was curious if this is intentional.  I'm also not sure if the mixin should be here or on polypeptide.