### PR TITLE
Add prefixes to chemical entity branch fixes #781

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7066,6 +7066,30 @@ classes:
       - UMLSSC:T085 # Molecular Sequence
     in_subset:
       - translator_minimal
+    id_prefixes:
+      - PUBCHEM.COMPOUND
+      - CHEMBL.COMPOUND
+      - UNII
+      - CHEBI
+      - DRUGBANK
+      - MESH
+      - CAS
+      - DrugCentral
+      - GTOPDB
+      - HMDB
+      - KEGG.COMPOUND
+      - ChemBank
+      - Aeolus
+      - PUBCHEM.SUBSTANCE
+      - SIDER.DRUG
+      - INCHI
+      - INCHIKEY
+      # - iupac # is not actually a CURIE namespace but only a naming convention for chemistry
+      # - SMILES  # is not actually a CURIE namespace but only a query language for chemistry
+      - KEGG.GLYCAN  ## G number
+      - KEGG.DRUG    ## D number
+      - KEGG.DGROUP  ## DG number
+      - KEGG.ENVIRON ## E number
 
   chemical entity:
     is_a: named thing
@@ -7096,6 +7120,31 @@ classes:
       - UMLSSC:T167 # Substance
     in_subset:
       - translator_minimal
+    id_prefixes:
+      - PUBCHEM.COMPOUND
+      - CHEMBL.COMPOUND
+      - UNII
+      - CHEBI
+      - DRUGBANK
+      - MESH
+      - CAS
+      - DrugCentral
+      - GTOPDB
+      - HMDB
+      - KEGG.COMPOUND
+      - ChemBank
+      - Aeolus
+      - PUBCHEM.SUBSTANCE
+      - SIDER.DRUG
+      - INCHI
+      - INCHIKEY
+      # - iupac # is not actually a CURIE namespace but only a naming convention for chemistry
+      # - SMILES  # is not actually a CURIE namespace but only a query language for chemistry
+      - KEGG.GLYCAN  ## G number
+      - KEGG.DRUG    ## D number
+      - KEGG.DGROUP  ## DG number
+      - KEGG.ENVIRON ## E number
+    
 
   chemical substance:
     deprecated: >-
@@ -7152,6 +7201,30 @@ classes:
       molecular entities.
     in_subset:
       - translator_minimal
+    id_prefixes:
+      - PUBCHEM.COMPOUND
+      - CHEMBL.COMPOUND
+      - UNII
+      - CHEBI
+      - DRUGBANK
+      - MESH
+      - CAS
+      - DrugCentral
+      - GTOPDB
+      - HMDB
+      - KEGG.COMPOUND
+      - ChemBank
+      - Aeolus
+      - PUBCHEM.SUBSTANCE
+      - SIDER.DRUG
+      - INCHI
+      - INCHIKEY
+      # - iupac # is not actually a CURIE namespace but only a naming convention for chemistry
+      # - SMILES  # is not actually a CURIE namespace but only a query language for chemistry
+      - KEGG.GLYCAN  ## G number
+      - KEGG.DRUG    ## D number
+      - KEGG.DGROUP  ## DG number
+      - KEGG.ENVIRON ## E number
 
   nucleic acid entity:
     is_a: molecular entity
@@ -7176,6 +7249,30 @@ classes:
     in_subset:
       - model_organism_database
       - translator_minimal
+    id_prefixes:
+      - PUBCHEM.COMPOUND
+      - CHEMBL.COMPOUND
+      - UNII
+      - CHEBI
+      - DRUGBANK
+      - MESH
+      - CAS
+      - DrugCentral
+      - GTOPDB
+      - HMDB
+      - KEGG.COMPOUND
+      - ChemBank
+      - Aeolus
+      - PUBCHEM.SUBSTANCE
+      - SIDER.DRUG
+      - INCHI
+      - INCHIKEY
+      # - iupac # is not actually a CURIE namespace but only a naming convention for chemistry
+      # - SMILES  # is not actually a CURIE namespace but only a query language for chemistry
+      - KEGG.GLYCAN  ## G number
+      - KEGG.DRUG    ## D number
+      - KEGG.DGROUP  ## DG number
+      - KEGG.ENVIRON ## E number
 
   molecular mixture:
     is_a: chemical mixture
@@ -7184,6 +7281,30 @@ classes:
       molecular entities with known concentration and stoichiometry.
     in_subset:
       - translator_minimal
+    id_prefixes:
+      - PUBCHEM.COMPOUND
+      - CHEMBL.COMPOUND
+      - UNII
+      - CHEBI
+      - DRUGBANK
+      - MESH
+      - CAS
+      - DrugCentral
+      - GTOPDB
+      - HMDB
+      - KEGG.COMPOUND
+      - ChemBank
+      - Aeolus
+      - PUBCHEM.SUBSTANCE
+      - SIDER.DRUG
+      - INCHI
+      - INCHIKEY
+      # - iupac # is not actually a CURIE namespace but only a naming convention for chemistry
+      # - SMILES  # is not actually a CURIE namespace but only a query language for chemistry
+      - KEGG.GLYCAN  ## G number
+      - KEGG.DRUG    ## D number
+      - KEGG.DGROUP  ## DG number
+      - KEGG.ENVIRON ## E number
 
   complex molecular mixture:
     is_a: chemical mixture
@@ -7192,6 +7313,30 @@ classes:
       more molecular entities with unknown concentration and stoichiometry.
     in_subset:
       - translator_minimal
+    id_prefixes:
+      - PUBCHEM.COMPOUND
+      - CHEMBL.COMPOUND
+      - UNII
+      - CHEBI
+      - DRUGBANK
+      - MESH
+      - CAS
+      - DrugCentral
+      - GTOPDB
+      - HMDB
+      - KEGG.COMPOUND
+      - ChemBank
+      - Aeolus
+      - PUBCHEM.SUBSTANCE
+      - SIDER.DRUG
+      - INCHI
+      - INCHIKEY
+      # - iupac # is not actually a CURIE namespace but only a naming convention for chemistry
+      # - SMILES  # is not actually a CURIE namespace but only a query language for chemistry
+      - KEGG.GLYCAN  ## G number
+      - KEGG.DRUG    ## D number
+      - KEGG.DGROUP  ## DG number
+      - KEGG.ENVIRON ## E number
 
   biological process or activity:
     description: >-

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7525,6 +7525,11 @@ classes:
       - RXCUI
       - NDC
       - PHARMGKB.DRUG
+      - DRUGBANK
+      - DrugCentral
+      - KEGG.DRUG    # D number
+      - KEGG.DGROUP  # DG number
+      - SIDER.DRUG
 
   ## Food
 

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7269,10 +7269,10 @@ classes:
       - INCHIKEY
       # - iupac # is not actually a CURIE namespace but only a naming convention for chemistry
       # - SMILES  # is not actually a CURIE namespace but only a query language for chemistry
-      - KEGG.GLYCAN  ## G number
-      - KEGG.DRUG    ## D number
-      - KEGG.DGROUP  ## DG number
-      - KEGG.ENVIRON ## E number
+      - KEGG.GLYCAN  # G number
+      - KEGG.DRUG    # D number
+      - KEGG.DGROUP  # DG number
+      - KEGG.ENVIRON # E number
 
   molecular mixture:
     is_a: chemical mixture

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7121,30 +7121,9 @@ classes:
     in_subset:
       - translator_minimal
     id_prefixes:
-      - PUBCHEM.COMPOUND
-      - CHEMBL.COMPOUND
       - UNII
-      - CHEBI
-      - DRUGBANK
       - MESH
-      - CAS
-      - DrugCentral
-      - GTOPDB
-      - HMDB
-      - KEGG.COMPOUND
-      - ChemBank
-      - Aeolus
-      - PUBCHEM.SUBSTANCE
-      - SIDER.DRUG
-      - INCHI
-      - INCHIKEY
-      # - iupac # is not actually a CURIE namespace but only a naming convention for chemistry
-      # - SMILES  # is not actually a CURIE namespace but only a query language for chemistry
-      - KEGG.GLYCAN  ## G number
-      - KEGG.DRUG    ## D number
-      - KEGG.DGROUP  ## DG number
-      - KEGG.ENVIRON ## E number
-    
+      - CAS #CAS numbers are given for things like plant extracts as well.
 
   chemical substance:
     deprecated: >-

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7093,7 +7093,6 @@ classes:
 
   chemical entity:
     is_a: named thing
-    abstract: true
     mixins:
       - physical essence
       - chemical or drug or treatment # issue 701


### PR DESCRIPTION
Only small molecule has any id_prefixes.  This is leading to trouble when trying to create the data for node normalizer.  That tool is only willing to use identifiers with prefixes that are part of that category's id_prefixes.