### PR TITLE
add prefixes back to protein

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7994,7 +7994,7 @@ classes:
     mixins:
       - gene product isoform mixin
     id_prefixes:
-      - UniProtKB ## UniProtKB:([A-Z0-9]+-\d+)
+      - UniProtKB # UniProtKB:([A-Z0-9]+-\d+)
       - UNIPROT.ISOFORM 
       - PR
       - ENSEMBL

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7967,6 +7967,12 @@ classes:
     mixins:
       - gene product mixin
       - thing with taxon
+    id_prefixes:
+      - UniProtKB
+      - PR
+      - ENSEMBL # ENSEMBL:ENSP*
+      - FB      # FlyBase FBpp*
+      - UMLS
     exact_mappings:
       - PR:000000001
       - SIO:010043


### PR DESCRIPTION
this is redundant with its parent's prefixes (polypeptide), we'll do this before the real fix comes from linkml.