### PR TITLE
"contraindicated for" mapping

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -5540,7 +5540,7 @@ slots:
       tag: biolink:canonical_predicate
       value: true
     exact_mappings:
-      - DrugCentral:0000001
+      - NCIT:C37933
       - RTXKG1:contraindicated_for
 
   has contraindication:


### PR DESCRIPTION
The mapping "DrugCentral:000001" is I think a bogus identifier that robokop made up in the translator feasibility phase, so it should be removed.
The only mapping I can find is to NCIT:C37933