### PR TITLE
Add UMLS as a prefix for molecular activity

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7538,6 +7538,7 @@ classes:
       - KEGG.REACTION  ## R number
       - KEGG.RCLASS    ## RC number
       - KEGG.ENZYME    ## EC number
+      - UMLS
 
   biological process:
     is_a: biological process or activity


### PR DESCRIPTION
https://github.com/TranslatorSRI/NodeNormalization/issues/78

UMLS contains terms that map to GO molecular activities.

The model includes UMLS types in the mapping of the molecular activity term itself, but does not allow UMLS prefixes.