### PR TITLE
Swap mixin order for behavior

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7631,8 +7631,8 @@ classes:
   behavior:
     is_a: biological process
     mixins:
-      - ontology class
       - activity and behavior
+      - ontology class
     exact_mappings:
       - GO:0007610
       # Behavior


### PR DESCRIPTION
Changing the position of 'activity and behavior' and 'ontology class' for the list of mixins for behavior.  This should be functionally the same thing, but prevents a MRO order TypeError in the python class translation, see https://github.com/linkml/linkml/issues/290