### PR TITLE
Change range for xref from iritype to uriorcurie

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -769,7 +769,7 @@ slots:
     is_a: node property
     aliases: ['dbxref', 'Dbxref', 'DbXref']
     domain: named thing
-    range: iri type
+    range: uriorcurie
     description: >-
       Alternate CURIEs for a thing
     multivalued: true


### PR DESCRIPTION
Changing the range for xref to a uri or curie instead of an IRI as I think this is an artifact from early biolink model development.