### PR TITLE
Fixes #61 Adding "has evidence" slot to association

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -6114,6 +6114,7 @@ slots:
       connects an association to an instance of supporting evidence
     exact_mappings:
       - RO:0002558
+    multivalued: true
 
   knowledge source:
     is_a: association slot


### PR DESCRIPTION
Domain was set as association class for 'has evidence' but the slot was not defined on the association class