### PR TITLE
add mechanism of action fixes #626, fixes #570

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -6174,10 +6174,10 @@ slots:
     multivalued: true
 
   mechanism of action:
-    is_a: assocation slot
+    is_a: association slot
     range: boolean
     description: >-
-      a boolean flag to indicate of the edge is part of a path or subgraph of a knowledge graph that constitutes
+      a boolean flag to indicate if the edge is part of a path or subgraph of a knowledge graph that constitutes
       the mechanism of action for a result.
     exact_mappings:
       - NCIT:C54680

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -6173,6 +6173,17 @@ slots:
       - RO:0002558
     multivalued: true
 
+  mechanism of action:
+    is_a: assocation slot
+    range: boolean
+    description: >-
+      a boolean flag to indicate of the edge is part of a path or subgraph of a knowledge graph that constitutes
+      the mechanism of action for a result.
+    exact_mappings:
+      - NCIT:C54680
+      - MI:2044
+      - LOINC:MTHU019741
+
   knowledge source:
     is_a: association slot
     description: >-


### PR DESCRIPTION
adding mechanism of action as per the chemical working group/DM decision to model MOA as a subgraph in a KG (therefore an association property that can be added to edges). 