### PR TITLE
Add OMIMPS as disease prefix

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7866,6 +7866,7 @@ classes:
       - MONDO
       - DOID
       - OMIM
+      - OMIMPS
       - ORPHANET
       - EFO
       - UMLS


### PR DESCRIPTION
OMIMPS should expand to `https://www.omim.org/phenotypicSeries/`.  I think that gets automatically pulled from prefix commons or somewhere, but I'm not 100% sure about that...