### PR TITLE
ci(makefile): add some robustness to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ json-schema: json-schema/biolink-model.json
 prefix-map: prefix-map/biolink-model-prefix-map.json
 
 build: python docs/index.md gen-golr-views biolink-model.graphql gen-graphviz java context.jsonld contextn.jsonld \
-json-schema/biolink-model.json biolink-model.owl.ttl biolink-model.proto biolink-model.shex biolink-model.ttl \
+json-schema/biolink-model.json biolink-model.owl.ttl biolink-model.proto shex biolink-model.ttl \
 prefix-map/biolink-model-prefix-map.json
 
 # TODO: Get this working
@@ -49,6 +49,7 @@ env.lock:
 # Python
 # ~~~~~~~~~~~~~~~~~~~~
 biolink/model.py: biolink-model.yaml env.lock
+	mkdir biolink 2>/dev/null || true
 	pipenv run gen-py-classes $< > $@.tmp && pipenv run python $@.tmp &&  mv $@.tmp $@
 
 
@@ -98,9 +99,11 @@ java: json-schema/biolink-model.json dir-java env.lock
 # JSON-LD CONTEXT
 # ~~~~~~~~~~~~~~~~~~~~
 context.jsonld: biolink-model.yaml env.lock
+	touch $@
 	pipenv run gen-jsonld-context $< > tmp.jsonld && ( pipenv run comparefiles tmp.jsonld $@ -c "^\s*\"comments\".*\n" && cp tmp.jsonld $@); rm tmp.jsonld
 
 contextn.jsonld: biolink-model.yaml env.lock
+	touch $@
 	pipenv run gen-jsonld-context --metauris $< > tmp.jsonld && ( pipenv run comparefiles tmp.jsonld $@ -c "^\s*\"comments\".*\n" && cp tmp.jsonld $@); rm tmp.jsonld
 
 
@@ -143,10 +146,13 @@ biolink-model.ttl: biolink-model.yaml env.lock
 biolink-model.shex: biolink-model.yaml
 	pipenv run gen-shex $< > $@
 biolink-modeln.shex: biolink-model.yaml
+	touch $@
 	pipenv run gen-shex --metauris $< > $@
 biolink-model.shexj: biolink-model.yaml
+	touch $@
 	pipenv run gen-shex --format json $< > $@
 biolink-modeln.shexj: biolink-model.yaml
+	touch $@
 	pipenv run gen-shex --metauris --format json $< > $@
 
 


### PR DESCRIPTION
This PR is minor improvement to Makefile

Normally build works fine, but when starting from scratch some commands can fail so PR just tries to avoid that.
- `biolink/model.py`  - No such directory
- `context*.jsonld` - No such file
- shex - missing input file

