### PR TITLE
Update PomBase gene prefix + add AspGD

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -8344,6 +8344,7 @@ classes:
       - WIKIDATA:Q7187
       - dcid:Gene
     id_prefixes:
+      - AspGD
       - NCBIGene
       - ENSEMBL
       - HGNC
@@ -8356,7 +8357,7 @@ classes:
       - FB  # FlyBase FBgn*
       - RGD
       - SGD
-      - POMBASE
+      - PomBase
       - OMIM
       - KEGG.GENE ## org:gene
       - UMLS


### PR DESCRIPTION
It looks like PomBase uses 'PomBase' as a prefix rather than 'POMBASE' 

I was also catching warnings from AspGD gene prefix (coming in from GO Annotations), so I added that.