### PR TITLE
add duration as an alias to timepoint and has quantitative value to c…

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -848,6 +848,7 @@ slots:
 
   timepoint:
     is_a: node property
+    aliases: ['duration']
     range: time type
     description: >-
       a point in time
@@ -9273,6 +9274,8 @@ classes:
   chemical exposure:
     mixins:
       - exposure event
+    slots:
+      - has quantitative value
     description: >-
       A chemical exposure is an intake of a particular
       chemical entity.


### PR DESCRIPTION
…hemical exposure.  fixes #956

@laurenechan
- I added an alias of duration to 'timepoint' as timepoint was already in the 'exposure' parent class.
- I added the existing slot 'has quantitative value' to the chemical exposure class.

After our conversation today, I think we also may need to move exposures from floating classes to being children of 'association,' however I'll do that in another ticket. 
 