### PR TITLE
fixes #984, fixes #987

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1284,6 +1284,7 @@ slots:
       	A role is particular behaviour which a material entity may exhibit.  Has role should be a curie from ChEBI
     range: uriorcurie
     pattern:  "^CHEBI:\\d{7}"
+    multivalued: true
 
   max tolerated dose:
     description: >-

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1280,12 +1280,11 @@ slots:
     multivalued: false
     range: boolean
 
-  has role:
+  has chemical role:
     is_a: node property
     description: >-
-      	A role is particular behaviour which a material entity may exhibit.  Has role should be a curie from ChEBI
-    range: uriorcurie
-    pattern:  "^CHEBI:\\d{7}"
+      	A role is particular behaviour which a material entity may exhibit.
+    range: chemical role
     multivalued: true
 
   max tolerated dose:
@@ -7029,6 +7028,9 @@ classes:
     in_subset:
       - samples
 
+  chemical role:
+    is_a: attribute
+
   biological sex:
     is_a: attribute
     exact_mappings:
@@ -7826,7 +7828,7 @@ classes:
       - available from
       - max tolerated dose
       - is toxic
-      - has role
+      - has chemical role
     exact_mappings:
       - CHEBI:24431
       - SIO:010004 # Chemical entity

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1279,6 +1279,15 @@ slots:
     multivalued: false
     range: boolean
 
+  has role:
+    description: >-
+      	A role is particular behaviour which a material entity may exhibit.  Has role should be a curie from ChEBI
+    exact_mapping:
+      - CHEBI:50906
+    range: uriorcurie
+    pattern:  "^CHEBI:\\d{7}"
+
+
   max tolerated dose:
     description: >-
       The highest dose of a drug or treatment that does not cause unacceptable side effects.
@@ -7817,6 +7826,7 @@ classes:
       - available from
       - max tolerated dose
       - is toxic
+      - has role
     exact_mappings:
       - CHEBI:24431
       - SIO:010004 # Chemical entity
@@ -8220,24 +8230,28 @@ classes:
       - CHEBI:64047
 
   nutrient:
+    deprecated: true
     is_a: chemical entity
     related_mappings:
       # substance role
       - CHEBI:33284
 
   macronutrient:
+    deprecated: true
     is_a: nutrient
     related_mappings:
       # substance role
       - CHEBI:33937
 
   micronutrient:
+    deprecated: true
     is_a: nutrient
     related_mappings:
       # substance role
       - CHEBI:27027
 
   vitamin:
+    deprecated: true
     is_a: micronutrient
     related_mappings:
       # substance role
@@ -8246,6 +8260,7 @@ classes:
       - STY:T127
 
   food:
+    deprecated: true
     is_a: chemical mixture
     description: >-
       A substance consumed by a living organism as a source of nutrition

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1282,11 +1282,8 @@ slots:
   has role:
     description: >-
       	A role is particular behaviour which a material entity may exhibit.  Has role should be a curie from ChEBI
-    exact_mapping:
-      - CHEBI:50906
     range: uriorcurie
     pattern:  "^CHEBI:\\d{7}"
-
 
   max tolerated dose:
     description: >-

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -93,6 +93,7 @@ prefixes:
   MESH: 'http://id.nlm.nih.gov/mesh/'
   MI: 'http://purl.obolibrary.org/obo/MI_'
   mirbase: 'http://identifiers.org/mirbase'
+  mmmp.biomaps: 'https://bioregistry.io/mmmp.biomaps:'
   MSigDB: 'https://www.gsea-msigdb.org/gsea/msigdb/'
   NBO-PROPERTY: 'http://purl.obolibrary.org/obo/nbo#'
   NCBIGene: 'http://identifiers.org/ncbigene/'

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1280,6 +1280,7 @@ slots:
     range: boolean
 
   has role:
+    is_a: node property
     description: >-
       	A role is particular behaviour which a material entity may exhibit.  Has role should be a curie from ChEBI
     range: uriorcurie

--- a/biolink/model.py
+++ b/biolink/model.py
@@ -1,5 +1,5 @@
 # Auto generated from biolink-model.yaml by pythongen.py version: 0.9.0
-# Generation date: 2022-03-29T19:10:25
+# Generation date: 2022-04-04T17:21:11
 # Schema: Biolink-Model
 #
 # id: https://w3id.org/biolink/biolink-model
@@ -262,6 +262,7 @@ LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
 MEDGEN = CurieNamespace('medgen', 'https://www.ncbi.nlm.nih.gov/medgen/')
 METACYC_REACTION = CurieNamespace('metacyc_reaction', 'https://identifiers.org/metacyc.reaction:')
 MIRBASE = CurieNamespace('mirbase', 'http://identifiers.org/mirbase')
+MMMP_BIOMAPS = CurieNamespace('mmmp_biomaps', 'https://bioregistry.io/mmmp.biomaps:')
 OBOINOWL = CurieNamespace('oboInOwl', 'http://www.geneontology.org/formats/oboInOwl#')
 OBOFORMAT = CurieNamespace('oboformat', 'http://www.geneontology.org/formats/oboInOwl#')
 OS = CurieNamespace('os', 'https://github.com/cmungall/owlstar/blob/master/owlstar.ttl')
@@ -2381,6 +2382,7 @@ class ChemicalEntity(NamedThing):
     available_from: Optional[Union[Union[str, "DrugAvailabilityEnum"], List[Union[str, "DrugAvailabilityEnum"]]]] = empty_list()
     max_tolerated_dose: Optional[str] = None
     is_toxic: Optional[Union[bool, Bool]] = None
+    has_role: Optional[Union[Union[str, URIorCURIE], List[Union[str, URIorCURIE]]]] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -2400,6 +2402,10 @@ class ChemicalEntity(NamedThing):
 
         if self.is_toxic is not None and not isinstance(self.is_toxic, Bool):
             self.is_toxic = Bool(self.is_toxic)
+
+        if not isinstance(self.has_role, list):
+            self.has_role = [self.has_role] if self.has_role is not None else []
+        self.has_role = [v if isinstance(v, URIorCURIE) else URIorCURIE(v) for v in self.has_role]
 
         super().__post_init__(**kwargs)
 
@@ -8577,6 +8583,10 @@ slots.available_from = Slot(uri=BIOLINK.available_from, name="available from", c
 
 slots.is_toxic = Slot(uri=BIOLINK.is_toxic, name="is toxic", curie=BIOLINK.curie('is_toxic'),
                    model_uri=BIOLINK.is_toxic, domain=NamedThing, range=Optional[Union[bool, Bool]])
+
+slots.has_role = Slot(uri=BIOLINK.has_role, name="has role", curie=BIOLINK.curie('has_role'),
+                   model_uri=BIOLINK.has_role, domain=NamedThing, range=Optional[Union[Union[str, URIorCURIE], List[Union[str, URIorCURIE]]]],
+                   pattern=re.compile(r'^CHEBI:\d{7}'))
 
 slots.max_tolerated_dose = Slot(uri=BIOLINK.max_tolerated_dose, name="max tolerated dose", curie=BIOLINK.curie('max_tolerated_dose'),
                    model_uri=BIOLINK.max_tolerated_dose, domain=NamedThing, range=Optional[str])


### PR DESCRIPTION
deprecate nutrient, etc. 
add 'has role' slot confined to "chemical entity" for now, with a ChEBI curie required. 