### PR TITLE
add CPT id prefix to procedure

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7630,7 +7630,9 @@ classes:
       - STY:T061
       # Molecular Biology Research Technique
       - STY:T063
-
+    id_prefixes:
+      - CPT
+      
   phenomenon:
     is_a: named thing
     mixins:


### PR DESCRIPTION
We plan to add a resource (Service Provider) that will connect indications (diseases) and procedures. The procedures will be CPT codes.

We think that the ID prefixes for procedures should be provided. 