### PR TITLE
Define subject and/or object on several associations

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -9717,11 +9717,15 @@ classes:
       - predicate
       - object
     slot_usage:
+      subject:
+        range: gene or gene product
       predicate:
         subproperty_of: homologous to
         symmetric: true
         description: >-
           homology relationship type
+      object:
+        range: gene or gene product
 
   gene expression mixin:
     description: >-
@@ -9986,6 +9990,9 @@ classes:
     mixins:
       - chemical to entity association mixin
     slot_usage:
+      subject:
+        range: chemical entity
+        description: "the chemical entity that is affecting the pathway"
       object:
         range: pathway
         description: "the pathway that is affected by the chemical"
@@ -10303,6 +10310,11 @@ classes:
       - disease to entity association mixin
     close_mappings:
       - dcid:DiseaseSymptomAssociation
+    slot_usage:
+      subject:
+        range: disease
+      object:
+        range: phenotypic feature
 
   case to phenotypic feature association:
     description: >-
@@ -10381,6 +10393,8 @@ classes:
         examples:
           - value: HGNC:2197
             description: "COL1A1 (Human)"
+      object:
+        range: phenotypic feature
 
   gene to disease association:
     is_a: association
@@ -10402,6 +10416,8 @@ classes:
         description: >-
           gene in which variation is correlated with the disease,
           may be protective or causative or associative, or as a model
+      object:
+        range: disease
 
   druggable gene to disease association:
     is_a: gene to disease association


### PR DESCRIPTION
This PR sets the subject & object ranges for associations used in the monarch ingest to classes. 

The context is that I'm moving from a python class generator from the model that previously allowed strings to be used on all class ranges to generated python code that is more literal, and I'm trying to avoid having associations where one side is a class and the other is a string. 

Classes that are updated include:
gene to gene homology association
chemical to pathway association
disease to phenotypic feature association
gene to phenotypic feature association
gene to disease association
