### PR TITLE
Replace recursive category range on NamedThing with regex

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7118,8 +7118,8 @@ classes:
       - provided by
     slot_usage:
       category:
-        range: named thing
         required: true
+        pattern: '^biolink:\d+$'
     exact_mappings:
       - BFO:0000001
       - WIKIDATA:Q35120


### PR DESCRIPTION
While working on linkml class generation and trying out varying degrees of class inlining, I found that if category were expected to be a NamedThing, and NamedThings needed to have a category, it wouldn't actually be possible to instantiate the circular dependency. This PR has a regex for the biolink prefix as an alternative solution.