### PR TITLE
Add food prefixes

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -8353,6 +8353,7 @@ classes:
       - FOODON
       - foodb.compound
       - UMLS
+      - NCIT
     exact_mappings:
       # Food
       - STY:T168

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -8350,7 +8350,9 @@ classes:
     description: >-
       A substance consumed by a living organism as a source of nutrition
     id_prefixes:
+      - FOODON
       - foodb.compound
+      - UMLS
     exact_mappings:
       # Food
       - STY:T168


### PR DESCRIPTION
To enable foodon/foodb concordance in nodenorm, we need foodon as an allowed prefix for food.

I also added UMLS, since there seems to be an STY for it, so I assume there are terms as well.