### PR TITLE
Add original subject, original predicate and original object to Association 

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -8207,6 +8207,9 @@ classes:
       - primary knowledge source
       - aggregator knowledge source
       - timepoint
+      - original subject
+      - original predicate
+      - original object
     slot_usage:
       type:
         description: rdf:type of biolink:Association should be fixed at rdf:Statement


### PR DESCRIPTION
It seems like these were intended to be top level association slots, if so, hopefully this PR is the right fix. 
