### PR TITLE
fix `acts upstream` predicate hierarchy

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1989,7 +1989,7 @@ slots:
     range: gene or gene product
 
   acts upstream of or within positive effect:
-    is_a: acts upstream of
+    is_a: acts upstream of or within
     domain: gene or gene product
     range: biological process
     annotations:
@@ -2004,7 +2004,7 @@ slots:
     range: gene or gene product
 
   acts upstream of or within negative effect:
-    is_a: acts upstream of
+    is_a: acts upstream of or within
     domain: gene or gene product
     range: biological process
     annotations:


### PR DESCRIPTION
`acts upstream of or within negative effect` and `acts upstream of or within positive effect` are subpredicates of `acts upstream of` instead of `acts upstream of or within`. This PR fixes this.

<img alt="acts_upstream_pb" src="https://user-images.githubusercontent.com/16098519/205140486-8acf0c9b-83cb-4be7-ae9b-dd4ec5fedae6.png">
