### PR TITLE
fix `caused by` predicate hierarchy

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -3085,7 +3085,7 @@ slots:
     description: >-
       holds between two entities where the occurrence, existence,
       or activity of one is caused by the occurrence or generation of the other
-    is_a: related to at instance level
+    is_a: contribution from
     aliases: [ 'disease caused by disruption of', 'disease has basis in dysfunction of',
                'realized in response to', 'realized in response to stimulus' ]
     in_subset:


### PR DESCRIPTION
`causes`is a subpredicate of `contributes to`, but its inverse `caused by` is not a subpredicate of `contribution from` but from `related to at instance level`:
<img width="369" alt="caused_by_pb" src="https://user-images.githubusercontent.com/16098519/205165136-38b62f84-362d-4eab-816a-6b29bcc1894c.png">

This PR fixes this issue.
