### PR TITLE
rename inverse of `capable of` predicate

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -4014,7 +4014,7 @@ slots:
       - NCIT:R52
       - RO:0002500
 
-  has capability:
+  can be carried out by:
     is_a: actively involves
     inverse: capable of
     domain: occurrent


### PR DESCRIPTION
`has capability` is not the inverse of `capable of`, it is a synonym! An inverse could be `can be carried out by`, as proposed by this PR.
