### PR TITLE
make type slot multivalued

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -500,6 +500,7 @@ slots:
       - AGRKB:soTermId
       - gff3:type
       - gpi:DB_Object_Type
+    multivalued: true
 
   category:
     is_a: type


### PR DESCRIPTION
stumbled upon this modeling publications that definitely have multiple types.
if it is `rdf:type` then it should be multivalued.