### PR TITLE
Fix the regex pattern used to check for the biolink:category CURIE

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -5611,7 +5611,7 @@ classes:
     slot_usage:
       category:
         required: true
-        pattern: '^biolink:\d+$'
+        pattern: '^biolink:[A-Z][A-Za-z]+$'
     exact_mappings:
       - BFO:0000001
       - WIKIDATA:Q35120


### PR DESCRIPTION
Previously it was accepting something like `biolink:123`, it has been changed to accept `biolink:[A-Z][A-Za-z]` as all biolink classes are composed of alphabetical characters starting with a capital letter

I noticed the issue while validating BioLink RDF with the BioLink SHACL shape, with this new pattern the SHACL shape properly validates `biolink:category` CURIEs