### PR TITLE
added mpath mappings

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -8020,6 +8020,7 @@ classes:
     exact_mappings:
       - OBI:1110122
       - NCIT:C16956
+      - MPATH:596
     narrow_mappings:
       # metastasis
       - NCIT:C19151
@@ -8043,6 +8044,8 @@ classes:
     is_a: anatomical entity
     mixins:
       - pathological entity mixin
+    exact_mappings:
+      - MPATH:603
 
   pathological anatomical exposure:
     is_a: attribute


### PR DESCRIPTION
for classes using the already mapped `pathological entity mixin`

in the current dev monarch neo4j dump some `mpath` entities are labeled with `pathological entity mixin` instead of one of the classes using it, probably because the mixin was mapped, but not the classes.

https://biolink.github.io/biolink-model/docs/PathologicalEntityMixin.html

![77d4054e](https://user-images.githubusercontent.com/16098519/221947925-0b885c82-5004-43a9-a2e5-42d095abb766.svg)

https://www.ebi.ac.uk/ols/ontologies/mpath/terms?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FMPATH_0&lang=en&viewMode=All&siblings=false

<img width="294" alt="Bildschirmfoto 2023-02-28 um 19 19 13" src="https://user-images.githubusercontent.com/16098519/221946963-de8148b6-418e-4a06-ac16-2d88e3c0c4dd.png">
