### PR TITLE
Update infores_catalog_nodes.tsv

### DIFF
--- a/infores_catalog_nodes.tsv
+++ b/infores_catalog_nodes.tsv
@@ -84,7 +84,7 @@ released	BioThings BindingDB API	infores:biothings-bindingdb	https://github.com/
 released	Biological Spatial Ontology 	infores:bspo	https://obofoundry.org/ontology/bspo.html	BSPO	KP			Information Resource					
 released	C. elegans Gross Anatomy Ontology	infores:wbbt	https://obofoundry.org/ontology/wbbt.html	WBBT			A structured controlled vocabulary of the anatomy of Caenorhabditis elegans.	Information Resource					
 released	C. elegans phenotype	infores:wbphenotype	https://obofoundry.org/ontology/wbphenotype.html	WBPhenotype			A structured controlled vocabulary of Caenorhabditis elegans phenotypes	Information Resource					
-released	CAM-KP API	infores:cam-kp	https://github.com/ExposuresProvider/cam-kp-api	Causal Activity Model KP	KP	['Exposures Provider']	TRAPI interface to database of Causal Activity Models	Information Resource					
+released	CAM-KP API	infores:cam-kp	https://github.com/NCATSTranslator/Translator-All/wiki/Exposures-Provider-CAM-AOP	Causal Activity Model KP	KP	['Exposures Provider']	TRAPI interface to database of Causal Activity Models	Information Resource					
 released	Clinical Asset Mapping Program for FHIR	infores:campfhir	https://researchsoftwareinstitute.github.io/data-translator/apps/camp-fhir	CAMP FHIR	KP			Information Resource					
 released	Chemical Entity of Biological Interest	infores:chebi	https://www.ebi.ac.uk/chebi/	ChEBI	KP		a freely available dictionary of molecular entities focused on ‘small’ chemical compounds	Information Resource					
 released	Chem2bio2RDF	infores:chem2bio2rdf	http://cheminfov.informatics.indiana.edu:8080/c2b2r/		KP			Information Resource					
@@ -181,10 +181,7 @@ released	ICD10AE (from UMLS)	infores:icd10ae-umls	https://www.nlm.nih.gov/resear
 released	ICD10CM (from UMLS)	infores:icd10cm-umls	https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/ICD10CM/index.html		KP			Information Resource					
 released	ICD10PCS (from UMLS)	infores:icd10pcs-umls	https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/ICD10PCS/index.html		KP			Information Resource					
 released	ICD9CM (from UMLS)	infores:icd9cm-umls	https://www.nlm.nih.gov/research/umls/sourcereleasedocs/current/ICD9CM/index.html		KP			Information Resource					
-released	ICEES	infores:icees	https://github.com/ExposuresProvider/icees-api		KP	['Exposures Provider']		Information Resource					
-released	ICEES Asthma Instance API	infores:icees-asthma	https://github.com/ExposuresProvider		KP	['Exposures Provider']		Information Resource					
-released	ICEES COVID-19 Instance API	infores:icees-covid19	https://github.com/ExposuresProvider		KP	['Exposures Provider']		Information Resource					
-released	ICEES DILI Instance API	infores:icees-dili	https://github.com/ExposuresProvider		KP	['Exposures Provider']		Information Resource					
+released	ICEES (Integrated Clinical and Environmental Exposures Service)	infores:icees-kg	https://github.com/NCATSTranslator/Translator-All/wiki/Exposures-Provider-ICEES		KP	['Exposures Provider']		Information Resource					released			
 released	integrated Dietary Supplement Knowledge Base	infores:idisk	https://conservancy.umn.edu/handle/11299/204783	iDISK	KP		https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7075538/	Information Resource					
 released	imProving Agent	infores:improving-agent	https://github.com/suihuanglab/improving-agent		ARA	['imProving Agent']	imProving Agent OpenAPI TRAPI Specification	Information Resource					
 released	OpenAPI for indigo NCATS Biomedical Translator Reasoner	infores:indigo-reasoner	https://github.com/NCATSTranslator/ReasonerAPI				OpenAPI for indigo NCATS Biomedical Translator Reasoner	Information Resource					


### PR DESCRIPTION
Updated information for cam-kp and icees-kg. Included URLs for Translator wiki pages, as discussed during the TAQA call on 03/31/2023.