### PR TITLE
Fix Wormbase ontology prefixes

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -151,8 +151,8 @@ prefixes:
   # See also: https://www.ga4gh.org/work_stream/genomic-knowledge-standards/#existing-standards and
   # https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7153148/
   VMC: 'https://github.com/ga4gh/vr-spec/'
-  WBls: 'http://purl.obolibrary.org/obo/WBBL_'
-  WBbt: 'http://purl.obolibrary.org/obo/WBBT_'
+  WBls: 'http://purl.obolibrary.org/obo/WBls_'
+  WBbt: 'http://purl.obolibrary.org/obo/WBbt_'
   WBVocab: 'http://bio2rdf.org/wormbase_vocabulary'
   WIKIDATA: 'https://www.wikidata.org/wiki/'            # Wikidata Entity
   WIKIDATA_PROPERTY: 'https://www.wikidata.org/wiki/Property:'  # Wikidata Property - not a conventional namespace prefix


### PR DESCRIPTION
Replaced Wormbase ontology prefixes with correct versions (see https://github.com/OBOFoundry/OBOFoundry.github.io/blob/671ddeaac290af0e4cd2165a54baead1664c6810/registry/obo_context.jsonld#L246-L247). Why don't these just get imported from the OBO prefixes file?