### PR TITLE
Fix incorrect domains and ranges of 'actively involved in'/'actively involves'

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -4138,15 +4138,13 @@ slots:
       holds between a continuant and a process or function, where
       the continuant actively contributes to part or all of
       the process or function it realizes
-    domain: occurrent
-    range: molecular activity
+    range: biological process or activity
     annotations:
       canonical_predicate: true
     in_subset:
       - translator_minimal
     exact_mappings:
       - RO:0002331
-      - RO:0002432
     narrow_mappings:
       - NBO-PROPERTY:by_means
       - orphanet:317348
@@ -4156,11 +4154,8 @@ slots:
 
   actively involves:
     is_a: has participant
-    domain: molecular activity
-    range: occurrent
+    domain: biological process or activity
     inverse: actively involved in
-    exact_mappings:
-      - RO:0002331
     in_subset:
       - translator_minimal
 


### PR DESCRIPTION
- In both predicates' domain/range 'occurrent' was used where a continuant should be.
- RO:0002331 was mapped to 'actively involved in' and also its inverse.
- RO:0002432 has incompatible domain/range to be mapped here