### PR TITLE
Move mapping to RO 'results in movement of'

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -4065,6 +4065,7 @@ slots:
       - PathWhiz:has_nucleic_acid
       - PathWhiz:has_protein
       - PathWhiz:has_reaction
+      - RO:0002565
       - RO:0004007
       - RO:0004020
       - RO:0004021
@@ -4123,7 +4124,6 @@ slots:
       - OBI:0000295
       - RO:0002216
       - RO:0002505
-      - RO:0002565
       - SNOMED:has_direct_device
 
   actively involved in:


### PR DESCRIPTION
Should be under 'has participant' rather than 'participates in'.