### PR TITLE
Improved CAM-KP infores entries

### DIFF
--- a/infores_catalog_nodes.tsv
+++ b/infores_catalog_nodes.tsv
@@ -112,7 +112,7 @@ released	Catalog of Somatic Mutations in Cancer	infores:cosmic	https://cancer.sa
 deprecated	Covid Phenotypes	infores:covid-phenotypes			KP			Information Resource					
 released	ConsensusPathDB	infores:cpdb	http://cpdb.molgen.mpg.de/	CPDB	KP			Information Resource					
 released	Current Procedural Terminology (CPT) Codes (from UMLS)	infores:cpt-codes-umls			KP			Information Resource					
-released	Comparative Toxicogenomics Database	infores:ctd	http://ctdbase.org	CTDbase	KP		"a robust, publicly available database that aims to advance understanding about how environmental exposures affect human health"	Information Resource					
+released	Comparative Toxicogenomics Database	infores:ctd	http://ctdbase.org	CTDbase	KP		"A robust, publicly available database that aims to advance understanding about how environmental exposures affect human health."	Information Resource					
 released	Cancer Therapeutics Response Portal	infores:ctrp	https://portals.broadinstitute.org/ctrp.v2.1/	CTRP	KP		"links genetic, lineage, and other cellular features of cancer cell lines to small-molecule sensitivity with the goal of accelerating discovery of patient-matched cancer therapeutics."	Information Resource					
 released	Drugs to target pAthways by the Tissue Expression	infores:date	http://tatonettilab.org/date/	DATE	KP			Information Resource					
 released	Single Nucleotide Polymorphism Database	infores:dbsnp	http://www.ncbi.nlm.nih.gov/SNP/	dbSNP	KP			Information Resource					
@@ -160,7 +160,7 @@ released	Genetics KP	infores:genetics-data-provider	https://github.com/broadinst
 released	Genetics Home Reference	infores:ghr	https://ghr.nlm.nih.gov/		KP			Information Resource					
 released	Global Network of Biomedical Relationships	infores:gnbr	https://zenodo.org/record/1035500	GNBR	KP			Information Resource					
 released	Gene Ontology	infores:go	http://www.geneontology.org/		KP			Information Resource					
-released	Gene Ontoogy Causal Activity Model Annotations	infores:go-cam	http://www.geneontology.org/	GO-CAM	KP			Information Resource					
+released	Gene Ontology Causal Activity Model Annotations	infores:go-cam	http://www.geneontology.org/docs/gocam-overview/	GO-CAM	KP			Information Resource					
 draft	Gene Ontology Plus	infores:go-plus		GO-Plus	KP			Information Resource					
 released	Gene Ontology Annotations	infores:goa	http://www.geneontology.org/	GOA	KP			Information Resource					
 released	GOTE (Gpcrs to dOwnstream cellular pathways byTissue Expression)	infores:gote	http://tatonettilab.org/resources/GOTE/source_code/	GOTE	KP			Information Resource					


### PR DESCRIPTION
This PR improves two CAM-KP-related infores entries:
1. Tidy the description of `infores:ctd`.
2. Fixed a typo and improved link (http://www.geneontology.org/ --> http://www.geneontology.org/docs/gocam-overview/) for `infores:go-cam`.

I can also confirm that the description of `infores:cam-kp` is correct.

cc @balhoff 