### PR TITLE
Propose definition for biolink:population_count

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -5375,6 +5375,14 @@ slots:
       The number of evidence instances that are connected to an association.
     range: integer
 
+  population count:
+    is_a: association slot
+    description: >-
+      The total number of instances (e.g., number of patients) in a dataset/cohort.
+    range: integer
+    examples:
+      - value: 100000
+
   concept count subject:
     is_a: association slot
     description: >-


### PR DESCRIPTION
For COHD, we would like to add an edge attribute to show the total population count for the dataset / cohort. This is just a suggested definition, and I am open to suggestions for changes as this is likely broadly applicable (outside COHD), @sierra-moxon @mbrush. 