### PR TITLE
remove reachable from enum

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -10677,15 +10677,6 @@ classes:
 
 enums:
 
-  AnatomicalContextQualifierEnum:
-    reachable_from:
-      source_ontology: bioregistry:uberon
-      source_nodes:
-        - UBERON:0001062
-      is_direct: false
-      relationship_types:
-        - rdfs:subClassOf
-
   DirectionQualifierEnum:
     permissible_values:
       increased:

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1513,7 +1513,6 @@ slots:
     description: >-
       A statement qualifier representing an anatomical location where an relationship expressed in an
       association took place (can be a tissue, cell type, or sub-cellular location).
-    range: AnatomicalContextQualifierEnum
     notes: >-
       Anatomical context values can be any term from UBERON. For example, the context qualifier ‘cerebral cortext’ 
       combines with a core concept of ‘neuron’ 

--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -616,7 +616,7 @@ information_resources:
   status: released
   name: Chemical Entity of Biological Interest
   xref:
-  - https://www.ebi.ac.uk/chebi/
+  - https://pubchem.ncbi.nlm.nih.gov/source/ChEBI
   synonym:
   - ChEBI
   description: a freely available dictionary of molecular entities focused on ‘small’


### PR DESCRIPTION
From Translator Architecture meeting: the dependency chain to include this functionality in BMT is more unstable than is required for September release.  Removing this for now.  We can revisit another modeling approach (at the moment, we do not think folks are using the enumerated values nor the constraint in validation).  