### PR TITLE
Add "full name" slot to the "named thing" slot list

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -6000,6 +6000,7 @@ classes:
     slots:
       - provided by
       - xref
+      - full name
     slot_usage:
       category:
         required: true


### PR DESCRIPTION
I associated the slot with full name, rather than entity (where name is) because the description of full name looks like it's specifically intended to be on named thing.

(My use case is to normalize on genes using symbol in the name slot, and the long form name in the full_name slot)
