### PR TITLE
fix: chemical-affects-gene-association aspect qualifier range

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -9423,7 +9423,7 @@ classes:
       subject derivative qualifier:
         range: ChemicalEntityDerivativeEnum
       subject aspect qualifier:
-        range: GeneOrGeneProductOrChemicalPartQualifierEnum
+        range: GeneOrGeneProductOrChemicalEntityAspectEnum
       subject context qualifier:
         range: anatomical entity
       subject direction qualifier:
@@ -9439,7 +9439,7 @@ classes:
       object part qualifier:
         range: GeneOrGeneProductOrChemicalPartQualifierEnum
       object aspect qualifier:
-        range: GeneOrGeneProductOrChemicalPartQualifierEnum
+        range: GeneOrGeneProductOrChemicalEntityAspectEnum
       object context qualifier:
         range: anatomical entity
       object direction qualifier:


### PR DESCRIPTION
chemical-affects-gene-association aspect qualifiers were set to the "Part" enum, when they should probably be set to the "Aspect" Enum. 

This was identified in https://github.com/biothings/biothings_explorer/issues/587#issuecomment-1635174361 (under Analyzing Errors, Qualifier_type_id for edge has unresolved qualifier_value (Knowledge Graph Edge Qualifier)