### PR TITLE
Update domain and range of gene condition association

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -3131,8 +3131,8 @@ slots:
     description: >-
       holds between a gene and a disease or phenotypic feature that the gene or its alleles/products may influence,
       contribute to, or correlate with
-    domain: disease or phenotypic feature
-    range: gene
+    domain: gene
+    range: disease or phenotypic feature
     annotations:
       canonical_predicate: true
     in_subset:
@@ -3151,8 +3151,8 @@ slots:
     aliases: ['disease associated with gene']
     description: >-
       holds between a gene and a disease or phenotypic feature that may be influenced, contribute to, or be correlated with the gene or its alleles/products
-    domain: gene
-    range: disease or phenotypic feature
+    domain: disease or phenotypic feature
+    range: gene
     in_subset:
       - translator_minimal
     inverse: gene associated with condition


### PR DESCRIPTION
This PR updates the domain and range of both the `gene associated with condition` and `condition associated with gene` to read consistently with the relationship wording. 

In the monarch rdf dataset I observed a discrepancy between how `gene associated with condition` is modeled in the instance level data vs the [biolink the documentation](https://biolink.github.io/biolink-model/docs/gene_associated_with_condition.html). For example, here is an instance from Monarch:

```turtle
uuid:f1fa9e99-ff74-11ed-9b68-e9f9ae56cff7 a biolink:Association ;
      rdf:subject hgnc:7877 ;
      rdf:predicate biolink:gene_associated_with_condition ;
      rdf:object mondo:MONDO_0034142 .
```

If I'm reading this correctly, the domain for `gene_associated_with_condition` should be `gene` and the range should be `disease or phenotypic feature` and vise versa for  `condition_associated_with_gene`.

