### PR TITLE
Adds synonym to named thing, removes it from gene

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -6008,6 +6008,7 @@ classes:
       - provided by
       - xref
       - full name
+      - synonym
     slot_usage:
       category:
         required: true
@@ -7879,7 +7880,6 @@ classes:
       - ontology class
     slots:
       - symbol
-      - synonym
       - xref
     exact_mappings:
       - SO:0000704


### PR DESCRIPTION
While trying to debug phenio's conversion to kgx, @caufieldjh spotted that diseases don't have a synonym slot, and that's why the property was getting dropped
