### PR TITLE
adding infores for MolePro new data source.

### DIFF
--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -1891,6 +1891,13 @@ information_resources:
       - https://archive.translator.ncats.io/
     knowledge level: curated
     agent type: not_provided
+  - id: infores:kinomescan
+    status: released
+    name: KINOMEscan
+    xref:
+      - https://lincs.hms.harvard.edu/kinomescan/
+    knowledge level: raw_data
+    agent type: experimental
   - id: infores:knowledge-collaboratory
     status: released
     name: Translator Knowledge Collaboratory API


### PR DESCRIPTION
note: this infores is preemptive, this data won't show up in TRAPI via MolePro until after September 2023 release.