### PR TITLE
Cx infores edits

### DIFF
--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -3461,3 +3461,24 @@ information_resources:
     description: >-
       SuppKG contains relations between dietary supplements and other entities, such as diseases. 
       More information can be found in [this paper](https://doi.org/10.1016/j.jbi.2022.104120).
+  - id: infores:biothings-ddinter
+    status: released
+    name: BioThings DDInter API
+    xref:
+      - https://github.com/NCATSTranslator/Translator-All/wiki/BioThings-DDInter-API
+    knowledge level: curated
+    agent type: not_provided
+    description: Documentation of the BioThings API for [DDInter](http://ddinter.scbdd.com/) data.
+  - id: infores:biothings-gtrx
+    status: released
+    name: BioThings GTRx API
+    xref:
+      - https://github.com/NCATSTranslator/Translator-All/wiki/BioThings-GTRx-API
+    knowledge level: curated
+    agent type: not_provided
+    description: >-
+      Documentation of the BioThings API for [Genome-to-Treatment (GTRx™)](https://gtrx.rbsapp.net/about.html). 
+      This API includes the content from the linked website, specifically the recommended acute treatments and 
+      interventions for seriously ill newborns, infants and children with newly diagnosed genetic diseases. 
+      These may include therapeutics, dietary changes, surgery, medical devices or other interventions. 
+      For more info, see the paper (open-access): https://www.nature.com/articles/s41467-022-31446-6.

--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -3496,3 +3496,16 @@ information_resources:
     description: >-
       Documentation of the BioThings API for [TherapeuticTargetDatabase](https://db.idrblab.net/ttd/).
       This KP contains drug-disease, target-disease, drug-protein target, and biomarker-disease associations.
+  - id: infores:rampdb
+    status: released
+    name: RaMPDB
+    xref:
+      - https://github.com/NCATSTranslator/Translator-All/wiki/RaMPDB
+    knowledge level: curated
+    agent type: not_provided
+    description: >-
+      RaMP-DB (Relational database of Metabolomic Pathways) is a multi-sourced integrated database 
+      with comprehensive annotations on biological pathways, structure/chemistry, disease and ontology 
+      annotations for genes, proteins, and metabolites. RaMP-DB also provides a framework for single 
+      and batch queries of those annotations, and for performing chemical and biological pathway 
+      enrichment analyses on input multi-omic datasets.

--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -374,7 +374,7 @@ information_resources:
       including GO, CHEBI, Uberon, and HPO. The redundant version of Ubergraph contains
       the complete inference closure for all subclass and existential relations, including
       transitive, reflexive subclass relations.
-  - id: infores:automat-viral-protome
+  - id: infores:automat-viral-proteome
     status: released
     name: Automat Viral Proteome
     knowledge level: curated

--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -3439,3 +3439,25 @@ information_resources:
     agent type: not_provided
     xref:
       - https://github.com/NCATSTranslator/Translator-All/wiki/Translator-f()%E2%80%90score
+  - id: infores:biothings-suppkg
+    status: released
+    name: BioThings SuppKG API
+    xref:
+      - https://github.com/NCATSTranslator/Translator-All/wiki/BioThings-SuppKG-API
+    knowledge level: curated
+    agent type: not_provided
+    description: >-
+      Documentation of the BioThings API for
+      [SuppKG](https://github.com/zhang-informatics/SemRep_DS/tree/main/SuppKG) data. SuppKG contains relations
+      between dietary supplements and other entities, such as diseases. More information can be found in [this 
+      paper](https://doi.org/10.1016/j.jbi.2022.104120). 
+  - id: infores:suppkg
+    status: released
+    name: SuppKG
+    xref:
+      - https://github.com/NCATSTranslator/Translator-All/wiki/SuppKG
+    knowledge level: text_mined
+    agent type: not_provided
+    description: >-
+      SuppKG contains relations between dietary supplements and other entities, such as diseases. 
+      More information can be found in [this paper](https://doi.org/10.1016/j.jbi.2022.104120).

--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -3273,7 +3273,7 @@ information_resources:
     knowledge level: curated
     agent type: not_provided
     description: >-
-      DDInter is anopen-access database specific to drug-drug interactions
+      DDInter is an open-access database specific to drug-drug interactions
       with annotations including mechanism description, risk levels, management strategies,
       alternative medications, etc. to improve clinical decision-making and patient
       safety.

--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -3081,11 +3081,15 @@ information_resources:
     status: released
     name: Therapeutic Target Database (TTD)
     xref:
-      - https://db.idrblab.net/ttd/
+      - https://github.com/NCATSTranslator/Translator-All/wiki/TTD
     synonym:
       - TTD
     knowledge level: curated
     agent type: not_provided
+    description: >-
+      TTD is a database providing information about the known and explored therapeutic protein 
+      and nucleic acid targets, the targeted disease, pathway information and the corresponding drugs 
+      directed at each of these targets.
   - id: infores:uberon
     status: released
     name: Uber Anatomy Ontology
@@ -3482,3 +3486,13 @@ information_resources:
       interventions for seriously ill newborns, infants and children with newly diagnosed genetic diseases. 
       These may include therapeutics, dietary changes, surgery, medical devices or other interventions. 
       For more info, see the paper (open-access): https://www.nature.com/articles/s41467-022-31446-6.
+  - id: infores:biothings-ttd
+    status: released
+    name: Biothings Therapeutic Target Database API
+    xref:
+      - https://github.com/NCATSTranslator/Translator-All/wiki/BioThings-TTD-API
+    knowledge level: curated
+    agent type: not_provided
+    description: >-
+      Documentation of the BioThings API for [TherapeuticTargetDatabase](https://db.idrblab.net/ttd/).
+      This KP contains drug-disease, target-disease, drug-protein target, and biomarker-disease associations.


### PR DESCRIPTION
Maybe helpful for Sept?
* https://github.com/biolink/biolink-model/pull/1391/commits/aaf9dcb02fc9b007cd3e9b19d4aff730d4b53fae edited the infores id for automat viral proteome: `infores:automat-viral-protome` ➡️  `infores:automat-viral-proteome`  It looks like this was a typo, since the [SmartAPI registration](http://smart-api.info/registry?q=465ff6de7ddf35ca8b2df6c0b01e6554)'s linked [yaml](https://trapi-openapi.apps.renci.org/trapi/infores:automat-viral-proteome/1.4.0) spells the info.x-translator.infores as `infores:automat-viral-proteome`. 
    * [BTE also uses this infores in the SRI testing data](https://github.com/NCATS-Tangerine/translator-api-registry/blob/022e8765adfed8a67feae9b8e3810c687c0e0e40/biothings_explorer/sri-test-bte-ara.json#L19). 

For post-Sept:
*  add entries that were missing, for already-existing KPs: https://github.com/biolink/biolink-model/pull/1391/commits/a00d3d83c294a0357fa80c2ed08581df907e0bff
    * `infores:biothings-ddinter`
    * `infores:biothings-gtrx`
* Add entries for upcoming KPs: 
    * `infores:biothings-suppkg` https://github.com/biolink/biolink-model/pull/1391/commits/c099821b12bf4c54d4911488143013ba60074562 
    * `infores:suppkg` (this has a [filled-out infores wiki page](https://github.com/NCATSTranslator/Translator-All/wiki/SuppKG)) https://github.com/biolink/biolink-model/pull/1391/commits/c099821b12bf4c54d4911488143013ba60074562 
    * `infores:biothings-ttd` https://github.com/biolink/biolink-model/pull/1391/commits/99827a7f2b50c3b7a23e66efa33a3cc9a34f2fff
    * `infores:rampdb` (this has a [filled-out infores wiki page](https://github.com/NCATSTranslator/Translator-All/wiki/RaMPDB)) https://github.com/biolink/biolink-model/pull/1391/commits/686c64045ab9ed7ef914c08fd0d555ce2a3dfb99
* Edit entries:
    *  `infores:ttd`: edited in prep for future use as a primary source for biothings-ttd https://github.com/biolink/biolink-model/pull/1391/commits/99827a7f2b50c3b7a23e66efa33a3cc9a34f2fff
        * for xref link, use a [filled-out infores wiki page](https://github.com/NCATSTranslator/Translator-All/wiki/TTD) instead
        * added a description
    *  `infores:ddinter`: fix minor typo in description https://github.com/biolink/biolink-model/pull/1391/commits/ac7cc4950defebf23c1ab3a04d23dbb654db4bad

(Note that infores wiki pages were only filled out for primary sources, and the other pages exist but say "info coming)