### PR TITLE
Update biolink-model-prefix-map.json to fix PMCID prefix expansion

### DIFF
--- a/prefix-map/biolink-model-prefix-map.json
+++ b/prefix-map/biolink-model-prefix-map.json
@@ -145,7 +145,7 @@
    "PHAROS": "http://pharos.nih.gov",
    "PIRSF": "http://identifiers.org/pirsf/",
    "PMC": "http://europepmc.org/articles/PMC",
-   "PMCID": "http://www.ncbi.nlm.nih.gov/pmc/",
+   "PMCID": "http://www.ncbi.nlm.nih.gov/pmc/PMC",
    "PMID": "http://www.ncbi.nlm.nih.gov/pubmed/",
    "PO": "http://purl.obolibrary.org/obo/PO_",
    "PR": "http://purl.obolibrary.org/obo/PR_",


### PR DESCRIPTION
added "PMC" to the end of the namespace for expanding the PMCID prefix to  "PMCID": "http://www.ncbi.nlm.nih.gov/pmc/PMC", to address #1366.