### PR TITLE
Add qualifier to Association

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -8944,7 +8944,8 @@ classes:
       - predicate
       - object
       - negated
-      - qualifiers
+      - qualifier
+      - qualifiers # deprecated
       - publications
       - has evidence
       - knowledge source


### PR DESCRIPTION
At Monarch we've been using the deprecated slot qualifiers, and as I was attempting to shift to qualifier I found that while it's defined as an association slot, it wasn't yet listed as one of the slots on the Association class
