### PR TITLE
Adds `deprecated` as a node property slot added to `named thing`

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -637,7 +637,6 @@ slots:
       - oboInOwl:hasRelatedSynonym
 
   deprecated:
-    is_a: node property
     range: boolean
     exact_mappings:
       - oboInOwl:ObsoleteClass
@@ -6006,6 +6005,7 @@ classes:
       - name
       - description
       - has attribute
+      - deprecated
        # evidence code(s)?
 
   named thing:
@@ -6016,7 +6016,6 @@ classes:
       - xref
       - full name
       - synonym
-      - deprecated
     slot_usage:
       category:
         required: true

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -636,6 +636,14 @@ slots:
     exact_mappings:
       - oboInOwl:hasRelatedSynonym
 
+  deprecated:
+    is_a: node property
+    range: boolean
+    exact_mappings:
+      - oboInOwl:ObsoleteClass
+    description: >-
+      A boolean flag indicating that an entity is no longer considered current or valid.
+
   has topic:
     aliases: ['topic', 'descriptors']
     is_a: node property
@@ -6008,6 +6016,7 @@ classes:
       - xref
       - full name
       - synonym
+      - deprecated
     slot_usage:
       category:
         required: true


### PR DESCRIPTION
I was surprised to see that the model doesn't yet have a way to represent that an entity is obsolete or deprecated. I could definitely use a double check on my exact_mapping to `oboInOwl:ObsoleteClass` and I'm not sure if we want to make the slot more targeted than allowing it for any named thing.
