### PR TITLE
Adds infores:aop-cam (Adverse Outcome Pathways Casual Activity Models)

### DIFF
--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -1621,6 +1621,15 @@ information_resources:
       - GO-CAM
     knowledge level: curated
     agent type: not_provided
+  - id: infores:aop-cam
+    status: released
+    name: Adverse Outcome Pathways Casual Activity Models
+    xref:
+      - https://github.com/NCATSTranslator/Translator-All/wiki/AOP-CAM
+    synonym:
+      - AOP-CAM
+    knowledge level: curated
+    agent type: not_provided
   - id: infores:go-plus
     status: released
     name: Gene Ontology Plus


### PR DESCRIPTION
This PR adds an infores entry for a new data source that is being incorporated into infores:automat-cam-kp -- Adverse Outcome Pathways Casual Activity Models from the AOP Wiki (https://aopwiki.org/), as described at https://github.com/NCATSTranslator/Translator-All/wiki/AOP-CAM.