### PR TITLE
Add RO mapping for gene/condition relations

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -3174,6 +3174,8 @@ slots:
       - translator_minimal
     inverse: gene associated with condition
     narrow_mappings:
+       # RO term implies causality making it narrower
+      - RO:0004000
        # narrower since just diseases, not phenotypic features as well
       - NCIT:R176
 


### PR DESCRIPTION
RO:0004000 is "condition has genetic basis in" and is a subproperty of "causally related to".

I think that it's therefore a narrow mapping of "condition associated with gene"