### PR TITLE
Add frequency quantifier mixin to disease to phenotypic feature association

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -10340,6 +10340,7 @@ classes:
       An association between a disease and a phenotypic feature in which the
       phenotypic feature is associated with the disease in some way.
     mixins:
+      - frequency quantifier
       - entity to phenotypic feature association mixin
       - disease to entity association mixin
     close_mappings:

--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -948,7 +948,7 @@ information_resources:
     status: released
     name: Connectivity Map
     xref:
-      - https://clue.io/cmap
+      - http://clue.io/cmap
     synonym:
       - CMAP
     knowledge level: curated

--- a/infores_catalog.yaml
+++ b/infores_catalog.yaml
@@ -1514,7 +1514,7 @@ information_resources:
     status: released
     name: National Cancer Institute Genomic Data Commons Data Portal
     xref:
-      - https://portal.gdc.cancer.gov/projects/
+      - https://portal.gdc.cancer.gov
     synonym:
       - GDC
     knowledge level: curated


### PR DESCRIPTION
To better represent the frequency column of HPOA phenotype annotations.