### PR TITLE
Remove rdfs:label slot_uri from in_taxon_label

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -5220,7 +5220,6 @@ slots:
       The human readable scientific name for the taxon of the entity.
     in_subset:
       - translator_minimal
-    slot_uri: rdfs:label
     exact_mappings:
       - WIKIDATA_PROPERTY:P225
     annotations:


### PR DESCRIPTION
This was causing kgx rdf conversion to say that the taxon label was a label for a gene record like so:

```
ncbigene:373942 bl:category bl:Gene .
ncbigene:373942 rdfs:label "AGMAT"^^xsd:string .
ncbigene:373942 dct:description "agmatinase"^^xsd:string .
ncbigene:373942 bl:provided_by "infores:ncbi-gene"^^xsd:string .
ncbigene:373942 bl:full_name "agmatinase"^^xsd:string .
ncbigene:373942 bl:in_taxon "NCBITaxon:9031"^^xsd:string .
ncbigene:373942 rdfs:label "Gallus gallus"^^xsd:string .
ncbigene:373942 bl:symbol "AGMAT"^^xsd:string .
```

