### PR TITLE
remove      - skos:relatedMatch as an exact mapping to biolink relate…

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1716,7 +1716,6 @@ slots:
     annotations:
       canonical_predicate: true
     exact_mappings:
-      - skos:relatedMatch
       - UMLS:related_to
       - SEMMEDDB:ASSOCIATED_WITH
       - SEMMEDDB:ADMINISTERED_TO


### PR DESCRIPTION
…d_to

fixes #1456 