### PR TITLE
Additional RO term to has_phenotype

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -3874,6 +3874,7 @@ slots:
       - NCIT:R89
       - DOID-PROPERTY:has_symptom
       - RO:0004022
+      - RO:0004029
 
   phenotype of:
     is_a: related to at instance level


### PR DESCRIPTION
Add RO:0004029 narrow mapping to has_phenotype so that these associations within Mondo will nicely map to the right predicate

