### PR TITLE
Update biolink-model.yaml - minor update to 'treats' def

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -3478,13 +3478,13 @@ slots:
     aliases: ['is substance that treats', 'indicated for', 'ameliorates or prevents condition']
     description: >-
       Holds between an intervention (substance, procedure, or activity) and a medical condition
-      (disease or phenotypic feature), and states that the intervention is able to ameliorate,
-      stabilize, or cure the condition or delay, prevent, or reduce the risk of it manifesting
-      in the first place.
+      (disease or phenotypic feature), and states that the intervention is, in some population(s), 
+      able to ameliorate, stabilize, or cure the condition or delay, prevent, or reduce the risk 
+      of it manifesting in the first place.
       ‘Treats’ edges should be asserted (knowledge_level: assertion) only in cases where there
-      is strong supporting evidence - i.e. the intervention is approved for the condition, passed
-      phase 3 or in phase 4 trials for the condition, or is an otherwise established 
-      treatment in the medical community (e.g. a widely-accepted or formally recommended 
+      is strong supporting evidence - i.e. in some population(s) the intervention is approved for
+      the condition, passed phase 3 or in phase 4 trials for the condition, or is an otherwise 
+      established treatment in the medical community (e.g. a widely-accepted or formally recommended 
       off-label use). In the absence of such evidence, weaker predicates should be used in 
       asserted edges (e.g. ‘in clinical trials for’ or ‘beneficial in models of’). ‘Treats’ edges
       based on weaker or indirect forms of evidence can however be created as predictions 


### PR DESCRIPTION
- added hedging language to the 'treats' definition indicating that efficacy need only be established in some population(s).  This supports use of 'treats' to cover Multiomics Approvals KP edges based on FDA database SPLs. Eps important if we decide to credit the FDA database as the primary source of these edges.