### PR TITLE
Add disease context qualifier and make it available only to phenotype associations (initially, at least)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ gen-project: $(PYMODEL)
 		-d $(DEST) $(SOURCE_SCHEMA_PATH) && mv $(DEST)/*.py $(PYMODEL)
 	mv $(DEST)/prefixmap/biolink_model.yaml $(DEST)/prefixmap/biolink_model_prefix_map.json
 	mv $(PYMODEL)/biolink*.py $(PYMODEL)/model.py
-	$(RUN) gen-pydantic --pydantic-version 2 src/biolink_model/schema/biolink_model.yaml > $(PYMODEL)/pydanticmodel_v2.py
+	$(RUN) gen-pydantic --version 2 src/biolink_model/schema/biolink_model.yaml > $(PYMODEL)/pydanticmodel_v2.py
 	$(RUN) gen-owl --mergeimports --no-metaclasses --no-type-objects --add-root-classes --mixins-as-expressions src/biolink_model/schema/biolink_model.yaml > $(DEST)/owl/biolink_model.owl.ttl
 	cp biolink-model.yaml src/biolink_model/schema/biolink_model.yaml
 	$(MAKE) id-prefixes

--- a/src/biolink_model/schema/biolink_model.yaml
+++ b/src/biolink_model/schema/biolink_model.yaml
@@ -1617,6 +1617,17 @@ slots:
     in_subset:
       - translator_minimal
 
+  disease context qualifier:
+    is_a: context qualifier
+    description: >-
+        A context qualifier representing a disease or condition in which a relationship expressed in an association took place.
+    range: disease
+    examples:
+      - value: MONDO:0004979 # Asthma
+      - value: MONDO:0005148 # type 2 diabetes mellitus
+    in_subset:
+        - translator_minimal
+
   qualifiers:
     deprecated: true
     description: >-
@@ -10256,6 +10267,7 @@ classes:
       - predicate
       - object
       - sex qualifier
+      - disease context qualifier
     defining_slots:
       - object
     slot_usage:


### PR DESCRIPTION
I aimed for being pretty targeted on the disease context qualifier, in that I'm only allowing it to be used when describing associations to phenotypes and providing the disease context in which that phenotype is occuring.  

cc:@ao33