### PR TITLE
Add species context qualifier to macromolecular machine association mixin

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -11187,6 +11187,7 @@ classes:
       - subject
       - predicate
       - object
+      - species context qualifier
     slot_usage:
       subject:
         domain: macromolecular machine mixin


### PR DESCRIPTION
Adding this specifically to handle the species context qualifier for GO associations, but it seems reasonable to assume that any association where a gene is the subject can have a species context qualifier that mirrors the taxon of the gene
