### PR TITLE
moves specialization qualifiers & disease context qualifier up to disease or phenotypic feature association

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -10380,10 +10380,6 @@ classes:
       - predicate
       - object
       - sex qualifier
-      - disease context qualifier
-      - subject specialization qualifier
-      - object specialization qualifier
-      - anatomical context qualifier
     defining_slots:
       - subject
       - predicate
@@ -10531,7 +10527,13 @@ classes:
       - subject
       - predicate
       - object
+      - disease context qualifier
+      - subject specialization qualifier
+      - object specialization qualifier
+      - anatomical context qualifier
     defining_slots:
+      - subject
+      - predicate
       - object
     slot_usage:
       object:


### PR DESCRIPTION
Ultimately where I need them is `chemical or drug or treatment to disease or phenotypic feature association` so it might also make sense that this association needs two children, to distinguish between associations to phenotypes and associations to diseases?
