### PR TITLE
Added "guanyl_nucleotide_exchange" as a molecular interaction aspect …

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -11861,6 +11861,8 @@ enums:
       molecular_interaction:
       guanyl_nucleotide_exchange:
         is_a: molecular_interaction
+      adenyl_nucleotide_exchange:
+        is_a: molecular_interaction
       molecular_modification:
       acetylation:
         is_a: molecular_modification

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -11859,6 +11859,8 @@ enums:
         is_a: transport
       splicing:
       molecular_interaction:
+      guanyl_nucleotide_exchange:
+        is_a: molecular_interaction
       molecular_modification:
       acetylation:
         is_a: molecular_modification


### PR DESCRIPTION
…under GeneOrGeneProductOrChemicalEntityAspectEnum:

Needed to fill a causal_mechanism_qualifier slot when the mechanism of one protein activating another occurs due to guanine exchange factor activity.