### PR TITLE
Add UMLS to biological process

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7678,6 +7678,7 @@ classes:
       - metacyc.reaction
       - KEGG.MODULE  ## M number
       - KEGG
+      - UMLS
 
   pathway:
     is_a: biological process


### PR DESCRIPTION
UMLS contains mappings to GO terms, including biological process terms.  But babel filters them out because UMLS is not an allowed prefix for BP.