### PR TITLE
add object_specialization_qualifier to gene to expression site association

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -11163,6 +11163,7 @@ classes:
     slots:
       - stage qualifier
       - quantifier qualifier
+      - object specialization qualifier
     slot_usage:
       subject:
         range: gene or gene product


### PR DESCRIPTION
Just makes object_specialization_qualifier available on GeneToExpressionSiteAssociation associations to represent anatomical postcomposition
