### PR TITLE
Add `sources` and `source record urls` to align with TRAPI

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -745,6 +745,7 @@ slots:
       an Edge provided by the ARAGORN ARA can expressing knowledge it
       retrieved from both the automat-mychem-info and molepro KPs,
       which both provided it with records of this single fact.
+    multivalued: true
     domain: retrieval source
     range: uriorcurie
 
@@ -7021,13 +7022,13 @@ classes:
       resource role:
         required: true
         description: >-
-            The role of the InformationResource in the retrieval of the
-            knowledge expressed in an Edge, or data used to generate this knowledge.
+          The role of the InformationResource in the retrieval of the
+          knowledge expressed in an Edge, or data used to generate this knowledge.
       upstream resource ids:
         description: >-
-          The InformationResources that served as a source for the
-          InformationResource that served as a source for the knowledge
-          expressed in an Edge, or data used to generate this knowledge.
+          A list of upstream InformationResources from which the resource
+          being described directly retrieved a record of the knowledge
+          expressed in the Edge, or data used to generate this knowledge.
 
    ## Top Level Abstractions of Material & Process Entities
 

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -9468,6 +9468,7 @@ classes:
       - qualifier
       - qualifiers  # deprecated
       - publications
+      - sources
       - has evidence
       - knowledge source
       - primary knowledge source

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1255,13 +1255,15 @@ slots:
 
   affinity:
     description: >-
-      The numerical value describing the strength of an affinity between two entities.  For instance, if a chemical inhibits a protein with a pIC50 of 8.6, the affinity is 8.6. Used in conjunction with the affinity parameter slot.
+      The numerical value describing the strength of an affinity between two entities.  For instance, if a chemical inhibits a protein with a pIC50 of 8.6,
+      the affinity is 8.6. Used in conjunction with the affinity parameter slot.
     is_a: association slot
     range: float
 
   affinity parameter:
     description: >-
-      The type of parameter describing the strength of an affinity between two entities.  For instance, if a chemical inhibits a protein with a pIC50 of 8.6, the affinity parameter is pIC50.  Used in conjunction with the affinity slot.
+      The type of parameter describing the strength of an affinity between two entities.  For instance, if a chemical inhibits a protein with a pIC50 of 8.6,
+      the affinity parameter is pIC50.  Used in conjunction with the affinity slot.
     is_a: association slot
     range: AffinityParameterEnum
 

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -749,6 +749,17 @@ slots:
     domain: retrieval source
     range: uriorcurie
 
+  source record urls:
+    is_a: node property
+    description: >-
+      A URL linking to a specific web page or document provided by the
+      source, that contains a record of the knowledge expressed in the
+      Edge. If the knowledge is contained in more than one web page on
+      an Information Resource's site, urls MAY be provided for each.
+    multivalued: true
+    domain: retrieval source
+    range: uriorcurie
+
   description:
     aliases: ['definition']
     range: narrative text
@@ -7012,6 +7023,7 @@ classes:
       - resource id
       - resource role
       - upstream resource ids
+      - source record urls
       - xref
     slot_usage:
       resource id:
@@ -7029,6 +7041,11 @@ classes:
           A list of upstream InformationResources from which the resource
           being described directly retrieved a record of the knowledge
           expressed in the Edge, or data used to generate this knowledge.
+      source record urls:
+        description: >-
+          One or more URLs that link to a specific web page or document provided by
+          the InformationResource, that contains a record of the knowledge expressed
+          in the Edge.
 
    ## Top Level Abstractions of Material & Process Entities
 

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -6010,6 +6010,25 @@ slots:
     multivalued: true
     range: publication
 
+  sources:
+    aliases: ['source retrieval provenance']
+    description: >-
+      A set of RetrievalSources, which traces where the statement expressed in an
+      Association came from. For example, the provenance of a Gene-Chemical Edge
+      might be traced through the Translator Resource that provided it (e.g. MolePro)
+      to one or more intermediate aggregator resources (e.g. ChEMBL), and finally to
+      the resource that originally created/curated it (e.g. ClinicalTrials.org).
+    comments: >-
+      Note that source retrieval provenance concerns the mechanical retrieval and
+      transformation of data between web accessible information systems. It does not
+      trace the source of knowledge back to specific publications or data sets. And
+      it is not concerned with the reasoning, inference or analysis activities that
+      generate knowledge in the first place (this is instead covered by 'knowledge
+      level' and 'agent type' properties).
+    is_a: association slot
+    multivalued: true
+    range: retrieval source
+
   associated environmental context:
     is_a: association slot
     description: >-


### PR DESCRIPTION
[EDIT] As part of the KGX+ handoff format work in Translator, we agreed that all node and edge properties should come from biolink-model. The format example uses TRAPI's `sources` and `source_record_urls` properties, which are missing from biolink-model. This PR adds them and makes minor adjustments to the existing RetrievalSource properties. 


References: TRAPI [sources](https://github.com/NCATSTranslator/ReasonerAPI/blob/67fb2d0eff8f1c8bd464ed83a5bf34b7563a83d8/TranslatorReasonerAPI.yaml#L1185), [source_record_urls](https://github.com/NCATSTranslator/ReasonerAPI/blob/67fb2d0eff8f1c8bd464ed83a5bf34b7563a83d8/TranslatorReasonerAPI.yaml#L1594) and [guide](https://github.com/NCATSTranslator/ReasonerAPI/blob/master/ImplementationGuidance/Specifications/retrieval_provenance_specification.md). 

@sierra-moxon This PR currently...
* doesn't include TRAPI guidance that resource IDs should be from infores registry. 
* ~doesn't add `sources` to the Association class's slots. I wasn't sure whether to do this or not.~ EDIT: added commit that does this
* doesn't adjust any existing, related slots/properties/classes:
  * `retrieval source ids`
  * `source web page`
  * `knowledge source`, `primary knowledge source`, `aggregator knowledge source`, `supporting data source` slots