### PR TITLE
Add `z score` edge property (from STATO)

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -9481,6 +9481,7 @@ classes:
       - qualifier
       - qualifiers  # deprecated
       - publications
+      - sources
       - has evidence
       - knowledge source
       - primary knowledge source

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1255,13 +1255,15 @@ slots:
 
   affinity:
     description: >-
-      The numerical value describing the strength of an affinity between two entities.  For instance, if a chemical inhibits a protein with a pIC50 of 8.6, the affinity is 8.6. Used in conjunction with the affinity parameter slot.
+      The numerical value describing the strength of an affinity between two entities.  For instance, if a chemical inhibits a protein with a pIC50 of 8.6,
+      the affinity is 8.6. Used in conjunction with the affinity parameter slot.
     is_a: association slot
     range: float
 
   affinity parameter:
     description: >-
-      The type of parameter describing the strength of an affinity between two entities.  For instance, if a chemical inhibits a protein with a pIC50 of 8.6, the affinity parameter is pIC50.  Used in conjunction with the affinity slot.
+      The type of parameter describing the strength of an affinity between two entities.  For instance, if a chemical inhibits a protein with a pIC50 of 8.6,
+      the affinity parameter is pIC50.  Used in conjunction with the affinity slot.
     is_a: association slot
     range: AffinityParameterEnum
 

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -6023,6 +6023,25 @@ slots:
     multivalued: true
     range: publication
 
+  sources:
+    aliases: ['source retrieval provenance']
+    description: >-
+      A set of RetrievalSources, which traces where the statement expressed in an
+      Association came from. For example, the provenance of a Gene-Chemical Edge
+      might be traced through the Translator Resource that provided it (e.g. MolePro)
+      to one or more intermediate aggregator resources (e.g. ChEMBL), and finally to
+      the resource that originally created/curated it (e.g. ClinicalTrials.org).
+    comments: >-
+      Note that source retrieval provenance concerns the mechanical retrieval and
+      transformation of data between web accessible information systems. It does not
+      trace the source of knowledge back to specific publications or data sets. And
+      it is not concerned with the reasoning, inference or analysis activities that
+      generate knowledge in the first place (this is instead covered by 'knowledge
+      level' and 'agent type' properties).
+    is_a: association slot
+    multivalued: true
+    range: retrieval source
+
   associated environmental context:
     is_a: association slot
     description: >-

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -749,6 +749,17 @@ slots:
     domain: retrieval source
     range: uriorcurie
 
+  source record urls:
+    is_a: node property
+    description: >-
+      A URL linking to a specific web page or document provided by the
+      source, that contains a record of the knowledge expressed in the
+      Edge. If the knowledge is contained in more than one web page on
+      an Information Resource's site, urls MAY be provided for each.
+    multivalued: true
+    domain: retrieval source
+    range: uriorcurie
+
   description:
     aliases: ['definition']
     range: narrative text
@@ -7025,6 +7036,7 @@ classes:
       - resource id
       - resource role
       - upstream resource ids
+      - source record urls
       - xref
     slot_usage:
       resource id:
@@ -7042,6 +7054,11 @@ classes:
           A list of upstream InformationResources from which the resource
           being described directly retrieved a record of the knowledge
           expressed in the Edge, or data used to generate this knowledge.
+      source record urls:
+        description: >-
+          One or more URLs that link to a specific web page or document provided by
+          the InformationResource, that contains a record of the knowledge expressed
+          in the Edge.
 
    ## Top Level Abstractions of Material & Process Entities
 

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -745,6 +745,7 @@ slots:
       an Edge provided by the ARAGORN ARA can expressing knowledge it
       retrieved from both the automat-mychem-info and molepro KPs,
       which both provided it with records of this single fact.
+    multivalued: true
     domain: retrieval source
     range: uriorcurie
 
@@ -7034,13 +7035,13 @@ classes:
       resource role:
         required: true
         description: >-
-            The role of the InformationResource in the retrieval of the
-            knowledge expressed in an Edge, or data used to generate this knowledge.
+          The role of the InformationResource in the retrieval of the
+          knowledge expressed in an Edge, or data used to generate this knowledge.
       upstream resource ids:
         description: >-
-          The InformationResources that served as a source for the
-          InformationResource that served as a source for the knowledge
-          expressed in an Edge, or data used to generate this knowledge.
+          A list of upstream InformationResources from which the resource
+          being described directly retrieved a record of the knowledge
+          expressed in the Edge, or data used to generate this knowledge.
 
    ## Top Level Abstractions of Material & Process Entities
 

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -5761,6 +5761,19 @@ slots:
     exact_mappings:
       - STATO:0000030
 
+  z score:
+    aliases: ['z-score', 'z-value', 'standard score', 'normal score']
+    is_a: association slot
+    range: float
+    description: >-
+      A measure of the divergence of an individual experimental result from
+      the most probable result, the mean. Z is expressed in terms of the number
+      of standard deviations from the mean value.
+    exact_mappings:
+      - STATO:0000104
+      - NCIT:C68741
+      - EDAM-DATA:1668
+
   p value:
     aliases: ['unadjusted p value']
     is_a: association slot


### PR DESCRIPTION
As part of the KGX+ handoff format work in Translator, we agreed that all node and edge properties should come from biolink-model. 

Currently, the [DISEASES text-mining ingest](https://github.com/NCATSTranslator/Data-Ingest-Coordination-Working-Group/issues/13#issuecomment-2816414540) includes the source data's z-score. Because z-score isn't in the biolink-model, we use [STATO:0000104](http://purl.obolibrary.org/obo/STATO_0000104) as the key. This PR adds z-score to the biolink model, so it can be used by this ingest. 

References: 
* For more details on DISEASES text-mining z-score, see the [Materials and methods section of the DISEASES paper](https://academic.oup.com/database/article/doi/10.1093/database/baac019/6554833?login=false#344427091)
* (used OLS to look up these terms) [STATO:0000104](http://purl.obolibrary.org/obo/STATO_0000104), [EDAM-DATA:1668](http://edamontology.org/data_1668), [NCIT:C68741](http://purl.obolibrary.org/obo/NCIT_C68741)

(Note: there's also an automated job that ran in my fork's master branch that's included in this PR)