### PR TITLE
Update gene variant qualifiers

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -11913,8 +11913,12 @@ enums:
       modified_form:
       loss_of_function_variant_form:
         is_a: genetic_variant_form
-      gain_of_function_variant_form:
+      non_loss_of_function_variant_form:
         is_a: genetic_variant_form
+      gain_of_function_variant_form:
+        is_a: non_loss_of_function_variant_form
+      dominant_negative_variant_form:
+        is_a: non_loss_of_function_variant_form
       polymorphic_form:
         is_a: genetic_variant_form
       snp_form:


### PR DESCRIPTION
In the EBI gene2pheno data, all associations have 1 [molecular_mechanism value](https://www.ebi.ac.uk/gene2phenotype/about/terminology#molecular-mechanism-section). 

I think this could be accounted for in our Translator ingest using the `subject_form_or_variant_qualifier` (on the gene). However, the resource uses several terms that aren't in the `ChemicalOrGeneOrGeneProductFormOrVariantEnum`: "dominant negative" and "undetermined non-loss-of-function". This PR adds these terms to the enum - which involved changing the hierarchy of values to reflect the [Review paper](https://doi.org/10.1146/annurev-genom-111221-103208) EBI gene2pheno bases its terms on.

(Note that "undetermined" means the functional effect wasn't noted, so I think the existing qualifier value `genetic_variant_form` will work there.)

---

(Note: there's also an automated job that ran in my fork's master branch that's included in this PR)