### PR TITLE
Make sources an inlined list on Association

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -9654,6 +9654,8 @@ classes:
       category:
         range: uriorcurie
         required: false
+      sources:
+        inlined_as_list: true
     exact_mappings:
       - OBAN:association
       - rdf:Statement


### PR DESCRIPTION
This uses slot usage to set `sources` to be inlined_as_list so that we can represent it as nested json. I wasn't sure if we wanted it to be a dictionary or list, but list seems just slightly easier to work with. 