### PR TITLE
Adding qualifier to ChemicalEntityToBiologicalProcessAssociation

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -10640,6 +10640,7 @@ classes:
       - species context qualifier
       - anatomical context qualifier
       - qualified predicate
+      - object direction qualifier
     slot_usage:
       subject:
         range: chemical entity


### PR DESCRIPTION
For CTD we planned edges with an object direction qualifier for ChemicalEntityToBiologicalProcessAssociations. This would enable that.