### PR TITLE
Change gene to disease or phenotypic association predicate

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -11530,7 +11530,7 @@ classes:
       object direction qualifier:
         range: DirectionQualifierEnum
       predicate:
-        subproperty_of: affects
+        subproperty_of: contributes to
     comments:
       - NCIT:R176 refers to the inverse relationship
       - for use in describing the affect that the loss of function of a gene can have on exacerbating or ameliorating a symptom/phenotype


### PR DESCRIPTION
association 'predicate.subproperty_of' slot_usage changed from 'affects' to 'contributes to', based on a deeper team consideration of the correct semantics of the association