### PR TITLE
Add CHEMBL.TARGET as ID prefix for MacromolecularComplex

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -9104,6 +9104,7 @@ classes:
       - GO
       - PR
       - REACT
+      - CHEMBL.TARGET
       - ComplexPortal
     in_subset:
       - model_organism_database


### PR DESCRIPTION
addresses #1678 