### PR TITLE
Add supporting_text slot to Association class

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -9990,6 +9990,7 @@ classes:
       - retrieval source ids
       - p value
       - adjusted p value
+      - supporting text
       - has supporting studies
       - update date
       - has confidence score


### PR DESCRIPTION
## Summary
- Adds the `supporting_text` slot to the base `Association` class, making it available on all association types
- Previously, this slot was only available on `TextMiningStudyResult`
- This enables curated knowledge sources (like dismech) to attach supporting text excerpts/snippets to any association

## Motivation
The dismech project exports curated disease mechanism knowledge to KGX format. We want to include supporting text snippets from publications along with associations, but found that `supporting_text` was restricted to `TextMiningStudyResult` only.

Making `supporting_text` available on all associations allows any knowledge source to provide textual evidence supporting their assertions, not just text-mining pipelines.
