### PR TITLE
add clinical approval status to association slot

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -10566,6 +10566,8 @@ classes:
       - object
     mixins:
       - entity to disease or phenotypic feature association mixin
+    slots:
+      - clinical approval status
     slot_usage:
       object:
         range: disease or phenotypic feature


### PR DESCRIPTION
**Urgent request**: this is needed by the DrugCentral ingest so we can label "treats" edges as off-label use. 

Right now, the ingest fails because this slot isn't explicitly included in the Association definition. 

<img width="1312" height="134" alt="Screenshot 2026-01-22 at 16 59 39" src="https://github.com/user-attachments/assets/879f59c8-03be-4c3e-ad0a-21e94fbdb1a9" />
