### PR TITLE
attributes.yaml: adjust diseases score to be float

### DIFF
--- a/attributes.yaml
+++ b/attributes.yaml
@@ -250,4 +250,4 @@ slots:
       A score defined by Jensen Lab Diseases that reports confidence level in an association on a scale of 1-5 stars. 
       It is based on different inputs for curated knowledge associations vs text-mined associations vs experimental/GWAS based associations,
       but adjusts/caps scores for these types of knowledge such that they are comparable on a single scale.
-    range: integer
+    range: float


### PR DESCRIPTION
**Urgent request** for the January QA work. I'm supposed to adjust the DISEASES ingest to use this edge property (https://github.com/NCATSTranslator/translator-ingests/issues/171), but the data is actually float. 

So this fix is needed so the updated ingest will still pass validation. 

