### PR TITLE
Add supporting study method types slot to association class

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -10006,6 +10006,7 @@ classes:
       - adjusted p value
       - supporting text
       - has supporting studies
+      - supporting study method types
       - update date
       - has confidence score
       - elevate to prediction


### PR DESCRIPTION
## Summary
- Add `supporting study method types` to the `association` class's slots list in `biolink-model.yaml`

The `supporting study method types` slot is already defined in the schema and inherits from `supporting study metadata` → `association slot`, but it was not explicitly declared in the `association` class's slots list. This adds it so that any association can explicitly declare supporting study method types.

Closes #1698