### PR TITLE
Add is_chemical_role_of as inverse of has_chemical_role

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1468,11 +1468,18 @@ slots:
       A role is particular behaviour which a chemical entity may exhibit.
     range: chemical role
     multivalued: true
+    inverse: is chemical role of
     id_prefixes:
       - CHEBI
     comments: >-
       We expect primarily to use CHEBI chemical roles here; however, we are looking for a mapping between
       CHEBI And ATC codes to support this slot.
+
+  is chemical role of:
+    is_a: related to at concept level
+    description: >-
+      Holds between a chemical role and a chemical entity that exhibits that role.
+    inverse: has chemical role
 
   max tolerated dose:
     description: >-


### PR DESCRIPTION
## Summary

- Adds `is chemical role of` as the inverse predicate of the canonical `has chemical role` predicate
- Adds `inverse: is chemical role of` to the existing `has chemical role` slot definition
- Follows the same pattern used by other inverse pairs in the model (e.g., `member of` / `has member`, `acts upstream of` / `has upstream actor`)

## Changes

In `biolink-model.yaml`:
- Added `inverse: is chemical role of` to the `has chemical role` slot
- Added new `is chemical role of` slot with `is_a: related to at concept level` and `inverse: has chemical role`