### PR TITLE
Novel top-level root class biolink:Component introduced for both full 'thing' (Entity) and lightweight annotation (e.g. Attribute, RetrievalSource)

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -328,6 +328,7 @@ slots:
     domain: entity
     range: attribute
     multivalued: true
+    inlined_as_list: true
     in_subset:
       - samples
     close_mappings:
@@ -6690,6 +6691,7 @@ slots:
     is_a: association slot
     multivalued: true
     range: retrieval source
+    inlined_as_list: true
 
   associated environmental context:
     is_a: association slot
@@ -7068,38 +7070,6 @@ classes:
       - has unit
       - has numeric value
 
-  attribute:
-    is_a: named thing
-    mixins:
-      - ontology class
-    description: >-
-      A property or characteristic of an entity.
-      For example, an apple may have properties such as color, shape, age, crispiness.
-      An environmental sample may have attributes such as depth, lat, long, material.
-    slots:
-      - name                    # 'attribute_name'
-      - has attribute type      # 'attribute_type'
-       # 'value', 'value_type', 'value_type_name'
-       # extracted from either of the next two slots
-      - has quantitative value
-      - has qualitative value
-      - iri                     # 'url'
-    slot_usage:
-      name:
-        description: >-
-          The human-readable 'attribute name' can be set to a string which reflects its context of
-          interpretation, e.g. SEPIO evidence/provenance/confidence annotation or it can default
-          to the name associated with the 'has attribute type' slot ontology term.
-    id_prefixes:
-      - EDAM-DATA
-      - EDAM-FORMAT
-      - EDAM-OPERATION
-      - EDAM-TOPIC
-    exact_mappings:
-      - SIO:000614
-    in_subset:
-      - samples
-
   chemical role:
     is_a: attribute
     description: >-
@@ -7201,23 +7171,113 @@ classes:
       - CHEBI
       - MAXO
 
+   ## ----------
+   ## COMPONENTS
+   ## ----------
+
+  component:
+    description: >-
+      Root Biolink Model class for all informational relationships, real or imagined.
+      A component can (though the Entity child class), but need not have, an identity
+      independent of its owning class. If it doesn't have such independent identity, 
+      then it should generally only be used as an inlined value of slot of a parent
+      class. For example, a RetrievalSource is always used as the value range of the
+      'sources' slot recording the provenance of an Association, hence, it is deemed
+      information not independent of the Association to which it is bound.
+    abstract: true
+    slots:
+      - category
+      - type    # rdf:type
+      - name
+      - description
+      - deprecated
+
+  attribute:
+    is_a: component
+    description: >-
+      An embedded property or characteristic of an Entity, only meaningful
+      in the context of its owning class, hence, generally inlined
+      (i.e., not an independent node in a knowledge graph). For example, 
+      an apple may have properties such as color, shape, age, crispiness.
+      An environmental sample may have attributes such as depth, lat, long, material.
+    slots:
+      - has attribute type      # 'attribute_type'
+       # 'value', 'value_type', 'value_type_name'
+       # extracted from either of the next two slots
+      - has quantitative value
+      - has qualitative value
+    slot_usage:
+      name:                    # 'attribute_name'
+        description: >-
+          The human-readable 'attribute name' can be set to a string which reflects its context of
+          interpretation, e.g. SEPIO evidence/provenance/confidence annotation or it can default
+          to the name associated with the 'has attribute type' slot ontology term.
+    id_prefixes:
+      - EDAM-DATA
+      - EDAM-FORMAT
+      - EDAM-OPERATION
+      - EDAM-TOPIC
+    exact_mappings:
+      - SIO:000614
+    in_subset:
+      - samples
+
+  retrieval source:
+    is_a: component
+    description: >-
+      Provides information about how a particular InformationResource
+      served as a source from which knowledge expressed in an Edge, or
+      data used to generate this knowledge, was retrieved.
+    slots:
+      - resource id
+      - resource role
+      - upstream resource ids
+      - source record urls
+      - xref
+    slot_usage:
+      resource id:
+        required: true
+        description: >-
+          The InformationResource that served as a source for the
+          knowledge expressed in an Edge, or data used to generate this knowledge.
+      resource role:
+        required: true
+        description: >-
+          The role of the InformationResource in the retrieval of the
+          knowledge expressed in an Edge, or data used to generate this knowledge.
+      upstream resource ids:
+        description: >-
+          A list of upstream InformationResources from which the resource
+          being described directly retrieved a record of the knowledge
+          expressed in the Edge, or data used to generate this knowledge.
+      source record urls:
+        description: >-
+          One or more URLs that link to a specific web page or document provided by
+          the InformationResource, that contains a record of the knowledge expressed
+          in the Edge.
+    examples:
+      - object:
+          id: urn:uuid:id
+          category: biolink:RetrievalSource
+          resource_id: infores:text-mining-provider-targeted
+          resource_role: primary_knowledge_source
+          upstream_resource_ids:
+            - infores:pubmed
+
    ## ------
    ## THINGS
    ## ------
 
   entity:
     description: >-
-      Root Biolink Model class for all things and informational relationships, real or imagined.
+      Root Biolink Model class for all things, real or imagined, 
+      which have a distinct identity (hence, globally unique identifier).
+    is_a: component
     abstract: true
     slots:
       - id
       - iri
-      - category
-      - type    # rdf:type
-      - name
-      - description
       - has attribute
-      - deprecated
        # evidence code(s)?
 
   named thing:
@@ -7793,48 +7853,6 @@ classes:
       or warnings for administration, storage and disposal instructions, etc.
     broad_mappings:
       - NCIT-OBO:C41203
-
-  retrieval source:
-    is_a: information content entity
-    description: >-
-      Provides information about how a particular InformationResource
-      served as a source from which knowledge expressed in an Edge, or
-      data used to generate this knowledge, was retrieved.
-    slots:
-      - resource id
-      - resource role
-      - upstream resource ids
-      - source record urls
-      - xref
-    slot_usage:
-      resource id:
-        required: true
-        description: >-
-          The InformationResource that served as a source for the
-          knowledge expressed in an Edge, or data used to generate this knowledge.
-      resource role:
-        required: true
-        description: >-
-          The role of the InformationResource in the retrieval of the
-          knowledge expressed in an Edge, or data used to generate this knowledge.
-      upstream resource ids:
-        description: >-
-          A list of upstream InformationResources from which the resource
-          being described directly retrieved a record of the knowledge
-          expressed in the Edge, or data used to generate this knowledge.
-      source record urls:
-        description: >-
-          One or more URLs that link to a specific web page or document provided by
-          the InformationResource, that contains a record of the knowledge expressed
-          in the Edge.
-    examples:
-      - object:
-          id: urn:uuid:id
-          category: biolink:RetrievalSource
-          resource_id: infores:text-mining-provider-targeted
-          resource_role: primary_knowledge_source
-          upstream_resource_ids:
-            - infores:pubmed
 
    ## Top Level Abstractions of Material & Process Entities
 
@@ -10469,8 +10487,6 @@ classes:
       category:
         range: uriorcurie
         required: false
-      sources:
-        inlined_as_list: true
       has supporting studies:
         inlined: true
     exact_mappings:


### PR DESCRIPTION
Created a novel root class for the entire model above **`biolink:Entity`**, demoting entity to being the secondary root of identified 'things', that is, **NamedThing** (nodes) and **Association** (edges).  Moved **`biolink:RetrievalSource`** directly under the new **`biolink:Component`** root. Also (big step!) moved **biolink:Attribute** there too (removed the **`mixin: ontology class`** too, since in fact, '**`has_attribute_type`**' is the best place for ontology in attributes?). Moved the '**`sources`**' slot '**`inlined_as_list`**' annotation from a '**`slot_usage`**' up to the definition of '**`sources`**'.