### PR TITLE
Attach SKOS synonym variants to named thing

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -7243,6 +7243,10 @@ classes:
       - xref
       - full name
       - synonym
+      - exact synonym
+      - broad synonym
+      - narrow synonym
+      - related synonym
       - equivalent identifiers
       - information content
       - taxon


### PR DESCRIPTION
## Summary
- Attaches `exact synonym`, `broad synonym`, `narrow synonym`, and `related synonym` to `named thing` alongside `synonym`.
- Without this, `SchemaView.class_slots(c)` never returns the variants for any class, so tools that flatten Biolink per-class (e.g. KGX-derived data from OBO ontologies) treat these columns as unknown.

Fixes #1737

## Test plan
- [x] `make test` passes
- [x] `linkml-lint` clean
- [ ] Confirm `SchemaView.class_slots('named thing')` includes the four variant slots after regeneration