### PR TITLE
Add DiseaseToDiseaseAssociation class

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -12150,6 +12150,39 @@ classes:
       object:
         range: phenotypic feature
 
+  disease to disease association:
+    is_a: association
+    defining_slots:
+      - subject
+      - object
+    description: >-
+      An association between two diseases. Captures clinical or biological
+      relationships such as comorbidity, sequela, post-infectious complication,
+      shared susceptibility, or differential diagnosis. The precise relationship
+      is carried by the predicate (e.g. ``associated with``, ``contributes to``,
+      ``risk affected by``, ``temporally related to``); use this class whenever
+      both ends of the association are diseases, rather than the more specific
+      ``disease to phenotypic feature association`` (which forces the object to
+      be a phenotypic feature) or a generic ``association``.
+    mixins:
+      - disease to entity association mixin
+      - entity to disease association mixin
+    slot_usage:
+      subject:
+        range: disease
+        description: "the disease that is the source/context of the association"
+        examples:
+          - value: MONDO:0005688
+            description: "campylobacteriosis (subject of: associated with Guillain-Barré syndrome as a post-infectious sequela)"
+      object:
+        range: disease
+        description: "the related disease"
+        examples:
+          - value: MONDO:0016218
+            description: "Guillain-Barré syndrome (object of: campylobacteriosis associated with Guillain-Barré syndrome)"
+      predicate:
+        subproperty_of: associated with
+
   case to phenotypic feature association:
     description: >-
       An association between a case (e.g. individual patient) and a phenotypic


### PR DESCRIPTION
## Summary

Adds a `disease to disease association` class to express disease-disease relationships such as comorbidity, post-infectious sequela, susceptibility/risk, and differential diagnosis. The class follows the same pattern as the existing `DiseaseToPhenotypicFeatureAssociation`, `DiseaseToExposureEventAssociation`, `CaseToDiseaseAssociation`, `GeneToDiseaseAssociation`, and `PhenotypicFeatureToDiseaseAssociation`.

```yaml
disease to disease association:
  is_a: association
  defining_slots:
    - subject
    - object
  mixins:
    - disease to entity association mixin
    - entity to disease association mixin
  slot_usage:
    subject:
      range: disease
    object:
      range: disease
    predicate:
      subproperty_of: associated with
```

**This PR contains only the schema edit (`biolink-model.yaml`).** Regenerated artifacts are intentionally omitted so maintainers can cut them in a separate "Regenerate artifacts from biolink-model.yaml" commit, matching the recent release pattern (e.g., `e6c171544`, `fc639fd79`, `8bc314374`).

## Motivation

Knowledge graph builds that surface disease-disease relationships have to fall back to the generic `biolink:Association` class today because no dedicated disease-disease class exists. Concrete example: the [monarch-initiative/dismech](https://github.com/monarch-initiative/dismech) KGX export emits ~36 edges of this shape — campylobacteriosis → Guillain-Barré, Lynch syndrome → colorectal/endometrial/ovarian cancers, antiphospholipid syndrome → preeclampsia, thymoma → myasthenia gravis. See [dismech#3177](https://github.com/monarch-initiative/dismech/pull/3177) for the matching exporter fix that routes these through a comorbidity edge.

The fallback works but loses the type information downstream tools could use to recognize and route disease-disease edges. Adding a dedicated class brings parity with the already-modeled `DiseaseToPhenotypicFeatureAssociation`, `DiseaseToExposureEventAssociation`, `CaseToDiseaseAssociation`, `GeneToDiseaseAssociation`, and `PhenotypicFeatureToDiseaseAssociation`.

## Local verification

- `make gen-project` ran clean and regenerated all derived artifacts (jsonld, jsonschema, owl, protobuf, shacl, shex, `model.py`, `pydanticmodel_v2.py`).
- `make test` passes: pytest (2/2), linkml-lint clean, codespell clean.
- Pydantic smoke test from the regenerated `pydanticmodel_v2.py`:

  ```python
  from biolink_model.datamodel.pydanticmodel_v2 import (
      DiseaseToDiseaseAssociation, KnowledgeLevelEnum, AgentTypeEnum,
  )
  d = DiseaseToDiseaseAssociation(
      id="x",
      subject="MONDO:0005688",          # campylobacteriosis
      predicate="biolink:associated_with",
      object="MONDO:0016218",            # Guillain-Barre syndrome
      knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
      agent_type=AgentTypeEnum.manual_agent,
  )
  ```

  Instantiates cleanly.

## Questions for the reviewer

- **Predicate scope.** I left `predicate: subproperty_of: associated with` to match `phenotypic feature to disease association`. If you'd prefer a more restrictive default (e.g. a `DiseaseToDiseasePredicateEnum` covering `associated with`, `contributes to`, `risk affected by`, `temporally related to`), happy to add.
- **Mapping suggestions.** I didn't add `close_mappings` or `exact_mappings`. Candidates I considered but wasn't confident enough about to commit: `SIO:000993` (related to), `NCIT:R175` (Disease_Has_Associated_Disease). Worth pulling in?
- **Examples directory.** `CLAUDE.md` says to add positive examples under `src/data/examples/valid/`, but that directory doesn't exist in the repo yet, so I held off. Tell me if you'd like me to bootstrap it for this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)