### PR TITLE
Add model-organism anatomy prefixes to GrossAnatomicalStructure

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -9374,6 +9374,14 @@ classes:
       - NCIT
       - PO
       - FAO
+      # model organism anatomy ontologies that include gross structures (organs, tissues),
+      # mirroring the model-organism prefixes on anatomical entity (see #1746)
+      - EMAPA  # mouse, e.g. subclasses of EMAPA:35949 "organ" and EMAPA:35868 "tissue"
+      - MA     # mouse adult anatomy
+      - ZFA    # zebrafish
+      - FBbt   # fly
+      - WBbt   # c. elegans
+      - XAO    # frog
 
 
   ## entity mixins


### PR DESCRIPTION
## Summary

Adds `EMAPA` and other model-organism anatomy prefixes to the valid `id_prefixes` for `biolink:GrossAnatomicalStructure`, addressing #1746 (filed by @gaurav for Babel/NodeNorm / DOGSLED).

EMAPA contains many mouse anatomical entities, including gross anatomical structures — e.g. subclasses of [EMAPA:35949 "organ"](http://purl.obolibrary.org/obo/EMAPA_35949) and [EMAPA:35868 "tissue"](http://purl.obolibrary.org/obo/EMAPA_35868) — but `EMAPA` was not a valid prefix for `GrossAnatomicalStructure`.

The issue also suggested checking whether other prefixes should be copied over. `biolink:AnatomicalEntity` (the parent) already lists several model-organism anatomy ontologies that `GrossAnatomicalStructure` lacked, so this PR mirrors that set:

| Prefix | Anatomy ontology |
|--------|------------------|
| `EMAPA` | mouse developmental anatomy |
| `MA`    | mouse adult anatomy |
| `ZFA`   | zebrafish anatomy |
| `FBbt`  | Drosophila anatomy |
| `WBbt`  | C. elegans anatomy |
| `XAO`   | Xenopus anatomy |

All six prefixes already resolve via the schema's default CURIE maps (to `http://purl.obolibrary.org/obo/<PREFIX>_`).

## Open question

`FMA` (human gross anatomy) is present on `AnatomicalEntity` but not added here, since it isn't a model-organism database. Happy to include it if maintainers think it belongs.

## Notes

- Only `biolink-model.yaml` is edited; generated `project/` artifacts are regenerated separately per repo convention.
- Schema validated with SchemaView; all prefixes resolve.

Fixes #1746
