### PR TITLE
updated condition prevented by predicate name and parent

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -3987,9 +3987,9 @@ slots:
     broad_mappings:
       - SEMMEDDB:PREVENTS
 
-  condition prevented by:
+  has preventative intervention:
     inverse: preventative for condition
-    is_a: affected by
+    is_a: likelihood affected by
     domain: disease or phenotypic feature
     range: chemical or drug or treatment
 


### PR DESCRIPTION
updated name of `condition prevented by` to soften it a bit, per Tyler's suggestion.  also changed parent predicate to be consistent with how related predicates are classified (e.g. predisposes to condition / condition predisposed by)

updated model: 
````
  has preventative intervention:
    inverse: preventative for condition
    is_a: likelihood affected by
    domain: disease or phenotypic feature
    range: chemical or drug or treatment
````