### PR TITLE
chemical entity to anatomical entity association

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -13847,6 +13847,20 @@ classes:
       predicate:
         subproperty_of: develops from
 
+  chemical entity or gene family to anatomical entity association:
+    is_a: association
+    description: >-
+      An association between a chemical entity (other than 'gene or gene product or gene family',
+      for example, a metabolite) and an anatomical entity, such as a tissue or subcellular location.
+    defining_slots:
+      - subject
+      - object
+    slot_usage:
+      subject:
+        range: chemical entity
+      object:
+        range: anatomical entity
+
   gene or gene product or gene family to anatomical entity association:
     is_a: association
     description: >-

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -13847,7 +13847,7 @@ classes:
       predicate:
         subproperty_of: develops from
 
-  chemical entity or gene family to anatomical entity association:
+  chemical entity to anatomical entity association:
     is_a: association
     description: >-
       An association between a chemical entity (other than 'gene or gene product or gene family',


### PR DESCRIPTION
Adding a subclass of Association which more specifically captures the relationship of a chemical entity (e.g. usually a metabolite, although not always?) and an anatomical entity at any suborganism biological level (organ, tissue, cell, cellular component)