### PR TITLE
Add IUPHAR target prefix for macromolecular complexes

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -10789,6 +10789,7 @@ classes:
       - evidence count
       - semmed agreement count
       - association basis qualifier
+      - species context qualifier
     slot_usage:
       type:
         description: rdf:type of biolink:Association should be fixed at rdf:Statement
@@ -10835,6 +10836,26 @@ classes:
           knowledge_level: knowledge_assertion
           agent_type: manual_agent
           publications: ["PMID:15289437"]
+      - description: >-
+          GtoPdb target 378 (5-HT3AB) is a source-defined macromolecular
+          complex. The same IUPHARobj identifier has species-specific protein
+          compositions, so each has_part assertion requires taxon context.
+        object:
+          subject: IUPHARobj:378
+          predicate: biolink:has_part
+          object: UniProtKB:P46098  # human HTR3A
+          category: biolink:Association
+          knowledge_level: knowledge_assertion
+          agent_type: manual_agent
+          species_context_qualifier: NCBITaxon:9606
+      - object:
+          subject: IUPHARobj:378
+          predicate: biolink:has_part
+          object: UniProtKB:P23979  # mouse Htr3a
+          category: biolink:Association
+          knowledge_level: knowledge_assertion
+          agent_type: manual_agent
+          species_context_qualifier: NCBITaxon:10090
       - object:
           subject: NCBIGene:4357  # MPST
           predicate: biolink:enables

--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -72,6 +72,7 @@ prefixes:
   GSID: 'https://scholar.google.com/citations?user='
   GTEx: 'https://www.gtexportal.org/home/gene/'
   GTOPDB: 'https://www.guidetopharmacology.org/GRAC/LigandDisplayForward?ligandId='
+  IUPHARobj: 'https://www.guidetopharmacology.org/GRAC/ObjectDisplayForward?objectId='
   gtpo: 'https://rdf.guidetopharmacology.org/ns/gtpo#'
   HANCESTRO: 'http://www.ebi.ac.uk/ancestro/ancestro_'
   HCPCS: 'http://purl.bioontology.org/ontology/HCPCS/'
@@ -9824,6 +9825,7 @@ classes:
       - REACT
       - CHEMBL.TARGET
       - ComplexPortal
+      - IUPHARobj
     in_subset:
       - model_organism_database
 

--- a/tests/test_canonical_annotation.py
+++ b/tests/test_canonical_annotation.py
@@ -40,3 +40,16 @@ def test_protein_accepts_ncit_prefix(load_biolink_model):
     protein = model.get_class("protein")
     assert protein is not None
     assert "NCIT" in protein.id_prefixes
+
+
+def test_macromolecular_complex_accepts_iuphar_target_prefix(load_biolink_model):
+    """Ensure GtoPdb target identifiers are valid for macromolecular complexes."""
+    model = SchemaView(load_biolink_model)
+    complex_class = model.get_class("macromolecular complex")
+
+    assert complex_class is not None
+    assert "IUPHARobj" in complex_class.id_prefixes
+    assert (
+        model.schema.prefixes["IUPHARobj"].prefix_reference
+        == "https://www.guidetopharmacology.org/GRAC/ObjectDisplayForward?objectId="
+    )


### PR DESCRIPTION
## Summary

- Add the `IUPHARobj` CURIE namespace for Guide to Pharmacology target records.
- Allow `IUPHARobj` identifiers on `biolink:MacromolecularComplex`.
- Permit `biolink:species_context_qualifier` on generic `biolink:Association`, including `biolink:has_part` assertions.
- Add paired human/mouse `IUPHARobj:378` (5-HT3AB) composition examples to demonstrate why the qualifier is required.
- Retain `GTOPDB` as the existing ligand-only namespace.

A single GtoPdb Target ID can describe species-specific protein compositions. Without a taxon-qualified `has_part` edge, downstream graph merging would attach components from multiple organisms to one `IUPHARobj` target. The associated conservative ingest policy is tracked in https://github.com/NCATSTranslator/translator-ingests/issues/510.

## Validation

- Regenerated derived artifacts and ran schema tests, LinkML lint, and YAML lint with the available workspace LinkML toolchain.
- The repository pinned `uv` environment could not be resolved on this host because the locked `cryptography` source build requires an unavailable `x86_64-apple-darwin` Rust target.