### PR TITLE
Drop invalid types: key from workflow_dispatch trigger

### DIFF
--- a/.github/workflows/release-deploy-docs.yaml
+++ b/.github/workflows/release-deploy-docs.yaml
@@ -5,7 +5,6 @@ on:
   release:
     types: [created]
   workflow_dispatch:
-    types: trigger-deploy-docs
 
 jobs:
   build-docs:


### PR DESCRIPTION
`workflow_dispatch` does not accept a `types:` field — that's a `repository_dispatch` idiom. GitHub silently ignored it (manual runs still worked), but it was misleading. This removes it so the manual trigger is well-formed.

No behavior change: the `release: [created]` auto-trigger and the manual "Run workflow" button both continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181pnh41TSauygoDurpPeL7