### PR TITLE
Rename FDA regulatory approvals slot to regulatory approvals

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -1647,10 +1647,14 @@ slots:
       approval for a specific condition, disease, phenotype, etc., see the association slot, 'clinical approval status.'
     range: ApprovalStatusEnum
 
-  FDA regulatory approvals:
+  regulatory approvals:
     description: >-
-      Numbers that identify specific drug applications. Each drug can have multiple approval numbers
-      (for example, as seen with ranitidine having both ANADA200536 and ANDA200536).
+      Numbers or identifiers issued by regulatory agencies that identify specific drug
+      applications or marketing authorizations. Values are application-number provenance
+      and are not guaranteed to be verified identifiers from any particular agency; they
+      may include FDA application numbers (for example, as seen with ranitidine having both
+      ANADA200536 and ANDA200536) as well as identifiers from other regulatory agencies such
+      as EMA marketing authorizations. Each drug can have multiple approval numbers.
     range: string
     multivalued: true
 
@@ -12305,7 +12309,7 @@ classes:
     slots:
       - clinical approval status
       - max research phase
-      - FDA regulatory approvals
+      - regulatory approvals
       - number of cases
 
   entity to feature or variant qualifiers mixin:
@@ -13593,7 +13597,7 @@ classes:
     description: >-
       An association between any entity and a disease, capturing
       clinical context such as approval status, research phase,
-      FDA regulatory approvals, and number of cases.
+      regulatory approvals, and number of cases.
     is_a: association
     exact_mappings:
     mixins:
@@ -13644,7 +13648,7 @@ classes:
     description: >-
       An association between any entity and a phenotypic feature,
       capturing clinical context such as approval status, research phase,
-      FDA regulatory approvals, and number of cases.
+      regulatory approvals, and number of cases.
     is_a: association
     exact_mappings:
     mixins:


### PR DESCRIPTION
## Summary

Renames the `FDA regulatory approvals` association slot to the agency-agnostic `regulatory approvals` and redocuments it, resolving #1799.

## Motivation

The slot was defined as FDA-scoped ("Numbers that identify specific drug applications"), but deployed producers populate it with application-number provenance that is not guaranteed to be FDA-issued — unregistered numbers, label-sourced IDs with invalid or missing application-type prefixes, and bare digit strings. This creates a semantic mismatch between the slot's definition and its deployed usage. An agency-agnostic home also accommodates planned future additions such as EMA marketing authorizations.

## Changes

- `biolink-model.yaml`:
  - Renamed slot `FDA regulatory approvals` → `regulatory approvals` and rewrote its description to cover regulatory application-number provenance from any agency (FDA application numbers such as ANADA200536/ANDA200536, as well as identifiers from other agencies such as EMA). `range: string` and `multivalued: true` are unchanged.
  - The old name is **not** retained as an alias.
  - Updated the slots list of `clinical trial and regulatory approval context mixin` and the descriptions of `entity to disease association` and `entity to phenotypic feature association` accordingly.

Derived artifacts (`project/*`, datamodels) are intentionally not included, per repo convention — the `push-main-regenerate-artifacts` workflow regenerates them on merge.

## Verification

- `make test`: 23/23 pytest passed, linkml-lint clean
- `yamllint -c .yamllint-config biolink-model.yaml`: clean

Resolves #1799