### PR TITLE
feat: allow population context qualifier on entity to disease and phenotypic feature associations

### DIFF
--- a/biolink-model.yaml
+++ b/biolink-model.yaml
@@ -12522,6 +12522,7 @@ classes:
       - subject specialization qualifier
       - object specialization qualifier
       - anatomical context qualifier
+      - population context qualifier
     defining_slots:
       - subject
       - predicate


### PR DESCRIPTION
## Summary

Adds `population context qualifier` to `entity to disease or phenotypic feature association mixin`, making it available on `entity to disease association`, `entity to phenotypic feature association`, and the other associations built on this shared mixin.

## Motivation

The `population context qualifier` slot already exists in the model (used by e.g. `exposure event to outcome association` and `named thing associated with likelihood of named thing association`), but the entity-to-disease/phenotype associations cannot use it: their shared mixin exposes `disease context qualifier` and `anatomical context qualifier` without a population-context counterpart. Producers of clinical drug-disease/phenotype edges, e.g. the DAKP ingest in `NCATSTranslator/translator-ingests`, which emits `biolink:EntityToDiseaseAssociation` / `biolink:EntityToPhenotypicFeatureAssociation`, need to constrain statements by the population they apply to (e.g. pregnancy, pediatric, or other label-defined subject populations from drug labels), rather than dropping that context or overloading `disease context qualifier`.

## Changes

- `biolink-model.yaml`:
  - Added `population context qualifier` to the slots of `entity to disease or phenotypic feature association mixin`. The mixin is the single shared qualifier vocabulary for `entity to disease association mixin` and `entity to phenotypic feature association mixin` (and thereby `entity to disease association` and `entity to phenotypic feature association`), so one slot entry covers all of them with no per-class duplication.
  - No new slot, enum, or class is introduced; the existing slot definition (range `population of individual organisms`) is unchanged.

Derived artifacts (`project/*`, datamodels) are intentionally not included, per repo convention; the `push-main-regenerate-artifacts` workflow regenerates them on merge.

## Verification

- `make lint`: linkml-lint clean
- `make test-python`: 24 passed
- `uv run yamllint -c .yamllint-config biolink-model.yaml`: clean
